### PR TITLE
K1 57 Save Player Data Logic

### DIFF
--- a/src/components/GamePlayer.tsx
+++ b/src/components/GamePlayer.tsx
@@ -1,26 +1,97 @@
 "use client";
 
 import UnityIFrame from "@/components/UnityIFrame";
+import { useState } from "react";
 
 type Props = {
   game: string;
 };
+
+interface ProgressPayload {
+  levelCompleted?: number;
+  completedLevels?: number[];
+  sessionId?: string;
+  classroomId?: string;
+  [key: string]: unknown;
+}
 
 // Temporary/demo wrapper for verifying the UnityIFrame bridge.
 // Production callers should pass real userId/sessionId/classroomId
 // and use onProgress to call the save endpoint.
 
 export default function GamePlayer({ game }: Props) {
+  const [saveId] = useState("test-save");
+  const [sessionId] = useState("test-session");
+
+  const handleProgress = async (payload: unknown) => {
+    const progressPayload = payload as ProgressPayload;
+    console.log("Unity progress received: ", progressPayload);
+
+    try {
+      // Save player progress to gameData endpoint
+      if (progressPayload.completedLevels && Array.isArray(progressPayload.completedLevels)) {
+        const response = await fetch(`/api/gameData/${saveId}`, {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            completedLevels: progressPayload.completedLevels,
+            lastUpdated: new Date().toISOString(),
+          }),
+        });
+
+        if (!response.ok) {
+          console.error("Failed to save game data:", response.statusText);
+          return;
+        }
+
+        const updatedData = await response.json();
+        console.log("Game data saved successfully:", updatedData);
+      }
+
+      // Create an event record for level completion
+      if (progressPayload.levelCompleted !== undefined && sessionId) {
+        const eventId = `level-complete-${game}-${progressPayload.levelCompleted}-${Date.now()}`;
+        const response = await fetch("/api/events", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            eventId,
+            anonUserId: "test-user",
+            sessionId,
+            event: "level_completed",
+            ts: new Date().toISOString(),
+            props: {
+              gameId: game,
+              levelCompleted: progressPayload.levelCompleted,
+            },
+          }),
+        });
+
+        if (!response.ok) {
+          console.error("Failed to save event:", response.statusText);
+          return;
+        }
+
+        const eventData = await response.json();
+        console.log("Event saved successfully:", eventData);
+      }
+    } catch (error) {
+      console.error("Error saving player data:", error);
+    }
+  };
+
   return (
     <UnityIFrame
       game={game}
-      saveId="test-save"
+      saveId={saveId}
       userId="test-user"
-      sessionId="test-session"
+      sessionId={sessionId}
       classroomId="test-classroom"
-      onProgress={(payload) => {
-        console.log("Unity progress received: ", payload);
-      }}
+      onProgress={handleProgress}
     />
   );
 }

--- a/src/components/GamePlayer.tsx
+++ b/src/components/GamePlayer.tsx
@@ -1,10 +1,14 @@
 "use client";
 
 import UnityIFrame from "@/components/UnityIFrame";
-import { useState } from "react";
+import { useAuth } from "@clerk/nextjs";
 
 type Props = {
   game: string;
+  saveId?: string;
+  sessionId?: string;
+  classroomId?: string;
+  userId?: string;
 };
 
 interface ProgressPayload {
@@ -19,12 +23,13 @@ interface ProgressPayload {
 // Production callers should pass real userId/sessionId/classroomId
 // and use onProgress to call the save endpoint.
 
-export default function GamePlayer({ game }: Props) {
-  const [saveId] = useState("test-save");
-  const [sessionId] = useState("test-session");
+export default function GamePlayer({ game, saveId, sessionId, classroomId, userId }: Props) {
+  const { userId: authUserId } = useAuth();
+  const resolvedUserId = userId ?? authUserId ?? undefined;
 
   const handleProgress = async (payload: unknown) => {
     const progressPayload = payload as ProgressPayload;
+    const resolvedSessionId = progressPayload.sessionId ?? sessionId;
     console.log("Unity progress received: ", progressPayload);
 
     try {
@@ -51,7 +56,7 @@ export default function GamePlayer({ game }: Props) {
       }
 
       // Create an event record for level completion
-      if (progressPayload.levelCompleted !== undefined && sessionId) {
+      if (progressPayload.levelCompleted !== undefined && resolvedSessionId && resolvedUserId) {
         const eventId = `level-complete-${game}-${progressPayload.levelCompleted}-${Date.now()}`;
         const response = await fetch("/api/events", {
           method: "POST",
@@ -60,8 +65,8 @@ export default function GamePlayer({ game }: Props) {
           },
           body: JSON.stringify({
             eventId,
-            anonUserId: "test-user",
-            sessionId,
+            anonUserId: resolvedUserId,
+            sessionId: resolvedSessionId,
             event: "level_completed",
             ts: new Date().toISOString(),
             props: {
@@ -88,9 +93,9 @@ export default function GamePlayer({ game }: Props) {
     <UnityIFrame
       game={game}
       saveId={saveId}
-      userId="test-user"
+      userId={resolvedUserId}
       sessionId={sessionId}
-      classroomId="test-classroom"
+      classroomId={classroomId}
       onProgress={handleProgress}
     />
   );

--- a/src/components/UnityIFrame.tsx
+++ b/src/components/UnityIFrame.tsx
@@ -8,15 +8,15 @@ import { useEffect, useRef } from "react";
 // useRef is a box that allows you to mutate values without triggering re-renders
 // .current is the saved data inside the box
 
-// This implementation assumes all data but saveId and classroomId is provided.
+// This implementation assumes callers provide session/user context when available.
 // workflow: React waits for unity to flag ready, then react sends context
 // it also assumes none of the variables will change very often during gameplay
 
 type Props = {
   game: string;
   saveId?: string;
-  userId: string;
-  sessionId: string;
+  userId?: string;
+  sessionId?: string;
   classroomId?: string;
   onProgress?: (payload: unknown) => void;
 };


### PR DESCRIPTION
## Developer: Vincent Le

Closes #k1-57

### Pull Request Summary

Added logic to save player data (level completions) to backend API.
Verified with Postman; ready for integration testing with backend

Events: await newEvent.save() → saves to events collection
GameData: await GameData.findOneAndUpdate(...) → updates gamedata collection


### Modifications

{list out the files created/modified and a brief description of what was changed}

### Testing Considerations

{list out what you have tested and what the reviewer should verify}

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our [guidelines](https://h4i.notion.site/Conventional-Commits-593452ad1179489399ad3bd696ef772a)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

<img width="1387" height="665" alt="image" src="https://github.com/user-attachments/assets/c7c3b73c-1774-48fc-bcb4-24795eb65f39" />
<img width="738" height="820" alt="image" src="https://github.com/user-attachments/assets/f11dc2ee-b554-4510-871f-3ed8ddf43ce4" />

