### PR TITLE
Support stable Unity stage progress

### DIFF
--- a/docs/game-progress-bridge.md
+++ b/docs/game-progress-bridge.md
@@ -1,0 +1,45 @@
+# Game Progress Bridge
+
+The embedded Unity games report progress to the website through the WebGL
+template's `window.postUnityProgress(payload)` function. The template wraps the
+payload in a same-origin `unity-progress` message; Unity code should not post a
+second message envelope directly.
+
+## Numeric Level Progress
+
+Penguin Run may continue to report numeric levels:
+
+```json
+{
+  "completedLevels": [1, 2],
+  "levelCompleted": 2
+}
+```
+
+## Stable Stage Progress
+
+Games with multiple activities or phases should report stable IDs:
+
+```json
+{
+  "completedStageIds": ["matter-kitchen/melt-chocolate", "matter-kitchen/pour-juice"],
+  "stageCompleted": {
+    "activityId": "matter-kitchen",
+    "stageId": "pour-juice",
+    "attempts": 1,
+    "completedAt": "2026-07-13T20:15:00.0000000Z"
+  }
+}
+```
+
+`completedLevels` and `completedStageIds` are complete save snapshots, not
+incremental additions. Send `levelCompleted` or `stageCompleted` only for the
+completion that triggered the message. The website stores the snapshot and
+uses the singular completion field for analytics.
+
+Activity and stage IDs use lowercase kebab case and must not be renamed when a
+Unity scene or display label changes. A stage's persisted key is
+`activityId/stageId`.
+
+The website accepts both formats so existing Penguin Run builds remain
+compatible while States of Matter moves away from scene names and numeric IDs.

--- a/docs/game-progress-bridge.md
+++ b/docs/game-progress-bridge.md
@@ -34,8 +34,9 @@ Games with multiple activities or phases should report stable IDs:
 
 `completedLevels` and `completedStageIds` are complete save snapshots, not
 incremental additions. Send `levelCompleted` or `stageCompleted` only for the
-completion that triggered the message. The website stores the snapshot and
-uses the singular completion field for analytics.
+completion that triggered the message. The website unions completion snapshots
+with stored progress so an older or newly initialized client cannot erase a
+completion. The singular completion field is used for analytics.
 
 Activity and stage IDs use lowercase kebab case and must not be renamed when a
 Unity scene or display label changes. A stage's persisted key is

--- a/src/app/api/gameData/[saveId]/route.ts
+++ b/src/app/api/gameData/[saveId]/route.ts
@@ -3,6 +3,14 @@ import { auth } from "@clerk/nextjs/server";
 import GameData from "@/database/gameDataSchema";
 import { NextResponse, NextRequest } from "next/server";
 
+function isIntegerArray(value: unknown): value is number[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "number" && Number.isInteger(item));
+}
+
+function isNonEmptyStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string" && item.length > 0);
+}
+
 export async function GET(_req: Request, { params }: { params: Promise<{ saveId: string }> }) {
   const { userId } = await auth();
   await connectDB();
@@ -24,11 +32,35 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ sa
       return NextResponse.json({ error: "Invalid patch" }, { status: 400 });
     }
 
-    const updated = await GameData.findOneAndUpdate(
-      { saveId },
-      { $set: changes },
-      { new: true, runValidators: true },
-    ).lean();
+    const patch = changes as Record<string, unknown>;
+    const hasCompletedLevels = Object.prototype.hasOwnProperty.call(patch, "completedLevels");
+    const hasCompletedStageIds = Object.prototype.hasOwnProperty.call(patch, "completedStageIds");
+
+    if (hasCompletedLevels && !isIntegerArray(patch.completedLevels)) {
+      return NextResponse.json({ error: "completedLevels must be an array of integers" }, { status: 400 });
+    }
+    if (hasCompletedStageIds && !isNonEmptyStringArray(patch.completedStageIds)) {
+      return NextResponse.json({ error: "completedStageIds must be an array of non-empty strings" }, { status: 400 });
+    }
+
+    const { completedLevels, completedStageIds, ...fieldsToSet } = patch;
+    const update: Record<string, unknown> = {};
+    const completionAdditions: Record<string, unknown> = {};
+
+    if (Object.keys(fieldsToSet).length > 0) {
+      update.$set = fieldsToSet;
+    }
+    if (hasCompletedLevels) {
+      completionAdditions.completedLevels = { $each: Array.from(new Set(completedLevels as number[])) };
+    }
+    if (hasCompletedStageIds) {
+      completionAdditions.completedStageIds = { $each: Array.from(new Set(completedStageIds as string[])) };
+    }
+    if (Object.keys(completionAdditions).length > 0) {
+      update.$addToSet = completionAdditions;
+    }
+
+    const updated = await GameData.findOneAndUpdate({ saveId }, update, { new: true, runValidators: true }).lean();
     if (!updated) {
       return NextResponse.json({ error: "Save not found" }, { status: 404 });
     }

--- a/src/components/GamePlayer.tsx
+++ b/src/components/GamePlayer.tsx
@@ -17,9 +17,43 @@ type Props = {
 interface ProgressPayload {
   levelCompleted?: number;
   completedLevels?: number[];
+  completedStageIds?: string[];
+  stageCompleted?: StageCompletion;
   sessionId?: string;
   classroomId?: string;
   [key: string]: unknown;
+}
+
+interface StageCompletion {
+  activityId: string;
+  stageId: string;
+  attempts?: number;
+  completedAt?: string;
+}
+
+function readNumberArray(value: unknown) {
+  return Array.isArray(value) && value.every((item) => typeof item === "number" && Number.isInteger(item))
+    ? value
+    : undefined;
+}
+
+function readStringArray(value: unknown) {
+  return Array.isArray(value) && value.every((item) => typeof item === "string" && item.length > 0) ? value : undefined;
+}
+
+function readStageCompletion(value: unknown): StageCompletion | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+
+  const candidate = value as Record<string, unknown>;
+  if (typeof candidate.activityId !== "string" || typeof candidate.stageId !== "string") return undefined;
+  if (!candidate.activityId || !candidate.stageId) return undefined;
+
+  return {
+    activityId: candidate.activityId,
+    stageId: candidate.stageId,
+    attempts: typeof candidate.attempts === "number" ? candidate.attempts : undefined,
+    completedAt: typeof candidate.completedAt === "string" ? candidate.completedAt : undefined,
+  };
 }
 
 // Temporary/demo wrapper for verifying the UnityIFrame bridge.
@@ -39,14 +73,24 @@ export default function GamePlayer({ game, saveId, sessionId, classroomId, userI
 
   const handleProgress = async (payload: unknown) => {
     const progressPayload = payload as ProgressPayload;
-    const resolvedSessionId = progressPayload.sessionId ?? sessionId;
+    const completedLevels = readNumberArray(progressPayload.completedLevels);
+    const completedStageIds = readStringArray(progressPayload.completedStageIds);
+    const stageCompleted = readStageCompletion(progressPayload.stageCompleted);
+    const levelCompleted =
+      typeof progressPayload.levelCompleted === "number" && Number.isInteger(progressPayload.levelCompleted)
+        ? progressPayload.levelCompleted
+        : undefined;
+    const resolvedSessionId = progressPayload.sessionId ?? sessionId ?? classroomSessionId;
+    const eventUserId =
+      resolvedUserId ?? (classroomParticipantId ? `participant:${classroomParticipantId}` : undefined);
     console.log("Unity progress received: ", progressPayload);
 
     try {
       // Save player progress to gameData endpoint
-      if (progressPayload.completedLevels && Array.isArray(progressPayload.completedLevels)) {
+      if (completedLevels || completedStageIds) {
         const payload = {
-          completedLevels: progressPayload.completedLevels,
+          ...(completedLevels ? { completedLevels } : {}),
+          ...(completedStageIds ? { completedStageIds } : {}),
           lastUpdated: new Date().toISOString(),
           classroomSessionId: classroomSessionId ?? null,
           classroomParticipantId: classroomParticipantId ?? null,
@@ -90,8 +134,11 @@ export default function GamePlayer({ game, saveId, sessionId, classroomId, userI
       }
 
       // Create an event record for level completion
-      if (progressPayload.levelCompleted !== undefined && resolvedSessionId && resolvedUserId) {
-        const eventId = `level-complete-${game}-${progressPayload.levelCompleted}-${Date.now()}`;
+      if ((levelCompleted !== undefined || stageCompleted) && resolvedSessionId && eventUserId) {
+        const completionId = stageCompleted
+          ? `${stageCompleted.activityId}-${stageCompleted.stageId}`
+          : String(levelCompleted);
+        const eventId = `level-complete-${game}-${completionId}-${Date.now()}`;
         const response = await fetch("/api/events", {
           method: "POST",
           headers: {
@@ -99,13 +146,14 @@ export default function GamePlayer({ game, saveId, sessionId, classroomId, userI
           },
           body: JSON.stringify({
             eventId,
-            anonUserId: resolvedUserId,
+            anonUserId: eventUserId,
             sessionId: resolvedSessionId,
             event: "level_completed",
             ts: new Date().toISOString(),
             props: {
               gameId: game,
-              levelCompleted: progressPayload.levelCompleted,
+              ...(levelCompleted !== undefined ? { levelCompleted } : {}),
+              ...(stageCompleted ?? {}),
             },
           }),
         });
@@ -128,8 +176,8 @@ export default function GamePlayer({ game, saveId, sessionId, classroomId, userI
       game={game}
       saveId={effectiveSaveId}
       userId={resolvedUserId}
-      sessionId={sessionId}
-      classroomId={classroomId}
+      sessionId={sessionId ?? classroomSessionId}
+      classroomId={classroomId ?? classroomSessionId}
       onProgress={handleProgress}
       height={height}
     />

--- a/src/database/gameDataSchema.ts
+++ b/src/database/gameDataSchema.ts
@@ -11,6 +11,7 @@ const gameDataSchema = new Schema({
   classroomParticipantId: { type: String, default: null, index: true },
   studentDisplayName: { type: String, default: null, trim: true },
   completedLevels: { type: [Number], default: [] },
+  completedStageIds: { type: [String], default: [] },
 });
 
 const GameData = mongoose.models.GameData || mongoose.model("GameData", gameDataSchema);


### PR DESCRIPTION
## What changed

- keeps support for Penguin Run's numeric `completedLevels` and `levelCompleted` payloads
- adds stable `completedStageIds` save snapshots and structured `stageCompleted` events
- persists stable stage IDs in `GameData`
- unions completion arrays atomically so stale or newly initialized Unity clients cannot erase saved progress
- validates completion arrays at the API boundary
- uses the active classroom session and participant identity when recording guest-player events
- documents the Unity-to-site progress protocol

## Why

The existing site bridge only persisted numeric levels, while States of Matter contains multiple activities and phases that should not be identified by scene names or arbitrary numbers. Its historical progress branch also posts the wrong message type (`unity_progress`) and bypasses the current same-origin WebGL template bridge.

The previous PATCH handler replaced completion snapshots. Because Unity currently persists locally, a fresh browser could send a partial snapshot and erase completions already stored by the website. Completion sets are now monotonic at the API boundary.

This establishes a backward-compatible contract before either Unity progress manager is merged.

## Validation

- `npm exec eslint -- 'src/app/api/gameData/[saveId]/route.ts' src/components/GamePlayer.tsx src/database/gameDataSchema.ts`
- `npm exec tsc -- --noEmit`
- `git diff --check`
- `npm run build` compiled and passed TypeScript, then stopped during prerender because `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY` is not configured in the local environment

## Compatibility

Existing numeric payloads remain valid. Stable IDs use `activityId/stageId`. Unity sends completion snapshots; the API unions them with stored progress so completion cannot move backward.
