### PR TITLE
fix: enforce API authorization and ownership

### DIFF
--- a/docs/api-authorization.md
+++ b/docs/api-authorization.md
@@ -1,0 +1,49 @@
+# API Authorization Policy
+
+API handlers are the authoritative security boundary. Browser route visibility and client-supplied IDs are not authorization.
+Middleware also returns `401` for anonymous access to APIs that are not part of the credentialed classroom flow.
+
+## Principals
+
+- **Clerk user:** Identified only by `auth().userId`. The `admin` role comes from the Clerk session claim. A user may self-select only `player`, `parent`, or `educator` during initial registration.
+- **Classroom participant:** A join code creates or resumes a participant and issues the `kfi_classroom_access` HTTP-only cookie. The cookie contains an opaque secret; only its SHA-256 digest is stored. Guest saves, quizzes, and events require a valid credential tied to an active classroom session.
+- **Educator:** A signed-in user with an educator database role. Classroom reads are additionally scoped through the corresponding `Teacher` and `ClassroomSession` records.
+
+Identity and ownership fields are always derived on the server. Request bodies cannot assign `userId`, `clerkId`, `classroomSessionId`, `studentDisplayName`, or an administrator role.
+Classroom records are keyed to the authorized participant, including for signed-in students, so attempts remain isolated by classroom session.
+
+## Route Inventory
+
+| Route                          | Method           | Access                                                         |
+| ------------------------------ | ---------------- | -------------------------------------------------------------- |
+| `/api/admin/:id/role`          | PATCH            | Administrator                                                  |
+| `/api/auth/admin-access`       | GET              | Administrator                                                  |
+| `/api/classroom-sessions`      | GET, POST, PATCH | Signed-in educator; sessions are teacher-scoped                |
+| `/api/classroom-sessions/join` | POST             | Public with an active access code; issues classroom credential |
+| `/api/events`                  | GET              | Administrator                                                  |
+| `/api/events`                  | POST             | Signed-in session owner or credentialed classroom participant  |
+| `/api/example`                 | GET              | Administrator                                                  |
+| `/api/gameData`                | GET              | Administrator                                                  |
+| `/api/gameData`                | POST             | Signed-in owner or credentialed classroom participant          |
+| `/api/gameData/:saveId`        | GET              | Owner, administrator, or educator who owns the classroom       |
+| `/api/gameData/:saveId`        | PATCH            | Owner only                                                     |
+| `/api/quiz`                    | GET              | Administrator                                                  |
+| `/api/quiz`                    | POST             | Signed-in owner or credentialed classroom participant          |
+| `/api/quiz/:id`                | GET              | Owner, administrator, or educator who owns the classroom       |
+| `/api/quiz/:id`                | PUT              | Owner or administrator                                         |
+| `/api/sessions`                | GET              | Administrator                                                  |
+| `/api/sessions`                | POST             | Signed-in user; owner is derived from Clerk                    |
+| `/api/sessions/:sessionId`     | GET, PATCH       | Session owner or administrator                                 |
+| `/api/users`                   | GET              | Administrator                                                  |
+| `/api/users`                   | POST             | Signed-in user creating or refreshing their own record         |
+| `/api/users/:id`               | GET, PUT         | Administrator                                                  |
+| `/api/users/me`                | GET              | Signed-in user                                                 |
+| `/api/users/me/photo`          | PATCH            | Signed-in user                                                 |
+
+## Response Rules
+
+- `401` means no valid Clerk or classroom credential was supplied.
+- `403` means the caller is authenticated but lacks the required role or participant binding.
+- `404` is used for inaccessible individual resources so ownership cannot be inferred.
+- `400` is limited to malformed or unsupported input.
+- Unexpected errors return a generic `500` response; detailed failures remain in server logs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
         "husky": "^9",
         "lint-staged": "^15",
         "prettier": "^3",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^4.1.11"
       }
     },
     "node_modules/@ark-ui/react": {
@@ -1373,6 +1374,16 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.144.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.144.0.tgz",
+      "integrity": "sha512-nuhZIOLuI6TFQ32I/WnUx+SCPY7SdSKwgnFHydAuoS1+Z4BRcaP+RRJmGzl9lw+0OFF7UmaESf7KQRXaNLHypg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@pandacss/is-valid-prop": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@pandacss/is-valid-prop/-/is-valid-prop-1.8.1.tgz",
@@ -1400,6 +1411,269 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.4.tgz",
+      "integrity": "sha512-jHC2cnyKz5xU2fhECtFl8OZ83cYNt13GZQD+0uMJ/X3o+ijmd56okHhTUwxVSHPx1IRVIJEZ1/1pPzeLCU6XKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-Dc5mPD8F5F/FS8i01syd7FTF6yB2fVthH/TRkjwJkzUK6EpoxHtqvZQP5Zwq80/5z19TWYHIg1KOHboCgVx/aQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-fpDm4oBo6SqLvWUYCmFhdde3U9KH2fRNNMeAnAPAIwxRL345xutL0EtEUcuoxsoazdJGv/MuDBQHlCDrtbvqOg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.4.tgz",
+      "integrity": "sha512-rSJoreDE/HoIzoaib6MTp5jQtCTdMHKIvItAKT/ImS6Y6Ww76oUaeMyp4Vc/fAgd/ehji068IxetHXAnqUwN9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.4.tgz",
+      "integrity": "sha512-/jm8OGHgn7oGaJu3i/qZI9spUGcJ+y/lk43ttQ/iO1tOd9NissG6o97bighBCiL+BKRngmcDuR6ikfwYdJmVuQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.4.tgz",
+      "integrity": "sha512-tIP06BeD9EqvECBrPZ+sqdPlYrT+aYaAiu1wYziVx5elRK/ftm33JxVDy2bXGbr6J0CrtirCkR87/X5a2euEng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.4.tgz",
+      "integrity": "sha512-Ql1Q0EQqVThvn9VAVlwNzsUvbSFtCMGjLpRRi4pk5i7NZZ4n5ISiLMjHYtus4VQ2PvkSw24zyaCVsiS+sXPj1w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.4.tgz",
+      "integrity": "sha512-GjbjXD4XXfN19D0LZNbmiCBUoDiRACsYHr0yaIbbn8aFsXjHZifcYqu/W5Er5X2X990WjHXFrxarn5chzItorQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.4.tgz",
+      "integrity": "sha512-p5WR0NOwaRmJ/B1b6IjEFLLivwEsf3PrdBIhRbhTCQisbo2SvHHpG4ELB/+FgQNnB88LTOF86upmJmbvZdQ2lw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.4.tgz",
+      "integrity": "sha512-4/GyVjmhR+Tc6HLJvwc1sOhPqAZtySiSMesOZyX6JQ5XBxoTDEMKQzvo07NIK6nTon/SivlZqvhzvuVBNQhObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.4.tgz",
+      "integrity": "sha512-l9eeLsCNvPpmSXUej0etw/J1eqV0Jj1D5G/xG6YTijmE6dkv6E2QezgWbTfQk63v952DPqrjOCoiqxq7Bw0YUQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.4.tgz",
+      "integrity": "sha512-e0F355MSTMm3+UOqtV3L24gFUp2N5m1f8L/7d56deik6va+AXdrt9F8LbzGpeWGWRbZEDq4m8NVnJDeBtf9DZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.4.tgz",
+      "integrity": "sha512-AWLi0uBRYh6QlE7OKhiz+phZC0qwtij2QZmhmOdsLdFn64m7oMpooE9ICE3lhm9xMb4SpDo2WbHcxX1iFLFtqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.4.tgz",
+      "integrity": "sha512-UwSDJOg3dqCAejWdxclJjCsh3Qq4vLYMDxmyHqo1btz3stK2VqgwNd3mm5tuIwzSlGIQ/1H9Hr+Zn09mrezNqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1418,6 +1692,13 @@
       "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -1426,6 +1707,31 @@
       "dependencies": {
         "tslib": "^2.8.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -1698,6 +2004,99 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@zag-js/accordion": {
       "version": "1.33.1",
@@ -2843,6 +3242,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -2990,6 +3399,16 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -3337,8 +3756,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -3525,6 +3944,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.0.0",
@@ -4048,6 +4474,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4084,6 +4520,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4275,6 +4721,21 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -5259,6 +5720,279 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.2.tgz",
@@ -5578,6 +6312,16 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/memory-pager": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
@@ -5784,15 +6528,16 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -6023,6 +6768,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -6177,6 +6936,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/perfect-freehand": {
       "version": "1.2.3",
@@ -6532,6 +7298,39 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.4.tgz",
+      "integrity": "sha512-rSr7irW0K7QRWzjdJXqZowkcRdDtjRduh43rBltnVKd0VFq839l1lJoDvGJb6gl7+4rTTCrPWu+YfujUL8Ug7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.144.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.4",
+        "@rolldown/binding-darwin-arm64": "1.2.4",
+        "@rolldown/binding-darwin-x64": "1.2.4",
+        "@rolldown/binding-freebsd-x64": "1.2.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.4",
+        "@rolldown/binding-linux-arm64-musl": "1.2.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-gnu": "1.2.4",
+        "@rolldown/binding-linux-x64-musl": "1.2.4",
+        "@rolldown/binding-openharmony-arm64": "1.2.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.4",
+        "@rolldown/binding-win32-x64-msvc": "1.2.4"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -6737,6 +7536,13 @@
       "resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
       "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ=="
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -6801,6 +7607,13 @@
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/standardwebhooks": {
       "version": "1.0.0",
@@ -7163,6 +7976,81 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7370,6 +8258,250 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/vitest/node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -7484,6 +8616,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
-    "test": "echo 'Install jest (or another unit test suite) to use this command.'",
+    "test": "vitest run",
     "prepare": "husky"
   },
   "dependencies": {
@@ -36,6 +36,7 @@
     "husky": "^9",
     "lint-staged": "^15",
     "prettier": "^3",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.11"
   }
 }

--- a/src/app/api/admin/[id]/role/route.ts
+++ b/src/app/api/admin/[id]/role/route.ts
@@ -1,24 +1,30 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth, clerkClient } from "@clerk/nextjs/server";
+import { clerkClient } from "@clerk/nextjs/server";
 import connectDB from "@/database/db";
 import User from "@/database/userSchema";
+import mongoose from "mongoose";
+import { getRequestActor, normalizeRole, requireAdmin } from "@/lib/server/apiAuthorization";
 
 export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const { userId, sessionClaims } = await auth();
-  if (!userId) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const admin = requireAdmin(await getRequestActor());
+  if (!admin.ok) return admin.response;
 
-  // IMPORTANT perhaps uncomment this in production
-  // if (sessionClaims?.role !== "admin") {
-  //   return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  // }
-
-  const { role } = await req.json();
+  const body = await req.json().catch(() => ({}));
+  const role = normalizeRole(body.role);
+  if (!role) {
+    return NextResponse.json({ error: "Invalid role" }, { status: 400 });
+  }
 
   await connectDB();
   const { id } = await params;
+  if (!mongoose.Types.ObjectId.isValid(id)) {
+    return NextResponse.json({ error: "Invalid user id" }, { status: 400 });
+  }
 
   // Update Mongo ( new: true will pass the updated document to mongo)
-  const updated = await User.findByIdAndUpdate(id, { role }, { new: true }).lean<{ clerkId: string } | null>();
+  const updated = await User.findByIdAndUpdate(id, { role }, { new: true, runValidators: true }).lean<{
+    clerkId: string;
+  } | null>();
   if (!updated) {
     return NextResponse.json({ error: "User not found" }, { status: 404 });
   }

--- a/src/app/api/auth/admin-access/route.ts
+++ b/src/app/api/auth/admin-access/route.ts
@@ -1,25 +1,14 @@
 import { NextResponse } from "next/server";
-import { auth, clerkClient } from "@clerk/nextjs/server";
+import { getRequestActor, requireAdmin } from "@/lib/server/apiAuthorization";
 
 export async function GET() {
   try {
-    const { userId } = await auth();
-
-    if (!userId) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-
-    const client = await clerkClient();
-    const user = await client.users.getUser(userId);
-    const role = user.publicMetadata?.role;
-
-    if (role !== "admin") {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-    }
+    const admin = requireAdmin(await getRequestActor());
+    if (!admin.ok) return admin.response;
 
     return NextResponse.json({ ok: true }, { status: 200 });
   } catch (error: any) {
     console.error("GET /api/auth/admin-access error:", error);
-    return NextResponse.json({ error: error?.message ?? "Failed to verify admin access" }, { status: 500 });
+    return NextResponse.json({ error: "Failed to verify admin access" }, { status: 500 });
   }
 }

--- a/src/app/api/classroom-sessions/join/route.ts
+++ b/src/app/api/classroom-sessions/join/route.ts
@@ -6,6 +6,11 @@ import ClassroomSession from "@/database/classroomSessionSchema";
 import StudentAccessCode from "@/database/studentAccessCodeSchema";
 import ClassroomParticipant from "@/database/classroomParticipantSchema";
 import User from "@/database/userSchema";
+import {
+  createClassroomCredential,
+  hashClassroomSecret,
+  setClassroomCredentialCookie,
+} from "@/lib/server/classroomAuthorization";
 
 function normalizeCode(value: string) {
   return value.trim().toUpperCase();
@@ -46,6 +51,7 @@ export async function POST(request: NextRequest) {
     }).lean<{
       _id: mongoose.Types.ObjectId;
       title: string;
+      expiresAt: Date;
     } | null>();
 
     if (!session) {
@@ -65,12 +71,13 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "A student name is required." }, { status: 400 });
     }
 
-    const participantKey = userId ? `clerk:${userId}` : guestToken ? `guest:${guestToken}` : "";
+    const participantKey = userId ? `clerk:${userId}` : guestToken ? `guest:${hashClassroomSecret(guestToken)}` : "";
 
     if (!participantKey) {
       return NextResponse.json({ error: "Unable to create a student session." }, { status: 400 });
     }
 
+    const credentialParticipantId = new mongoose.Types.ObjectId();
     const participant = await ClassroomParticipant.findOneAndUpdate(
       { sessionId: session._id, participantKey },
       {
@@ -81,6 +88,7 @@ export async function POST(request: NextRequest) {
           lastSeenAt: new Date(),
         },
         $setOnInsert: {
+          _id: credentialParticipantId,
           joinedAt: new Date(),
         },
       },
@@ -96,11 +104,18 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Unable to create a student session." }, { status: 500 });
     }
 
+    const participantCredential = createClassroomCredential(String(participant._id));
+    await ClassroomParticipant.updateOne(
+      { _id: participant._id },
+      { $set: { authTokenHash: participantCredential.tokenHash } },
+    );
+
     await StudentAccessCode.findByIdAndUpdate(accessCode._id, { $set: { lastSeenAt: new Date() } });
 
-    return NextResponse.json(
+    const response = NextResponse.json(
       {
         sessionId: String(session._id),
+        expiresAt: session.expiresAt.toISOString(),
         title: session.title,
         participant: {
           id: String(participant._id),
@@ -111,8 +126,10 @@ export async function POST(request: NextRequest) {
       },
       { status: 200 },
     );
+    setClassroomCredentialCookie(response, participantCredential.cookieValue, session.expiresAt);
+    return response;
   } catch (error: any) {
     console.error("POST /api/classroom-sessions/join error:", error);
-    return NextResponse.json({ error: error?.message ?? "Failed to join classroom session." }, { status: 500 });
+    return NextResponse.json({ error: "Failed to join classroom session." }, { status: 500 });
   }
 }

--- a/src/app/api/classroom-sessions/route.ts
+++ b/src/app/api/classroom-sessions/route.ts
@@ -121,7 +121,7 @@ export async function GET() {
     return NextResponse.json({ session }, { status: 200 });
   } catch (error: any) {
     console.error("GET /api/classroom-sessions error:", error);
-    return NextResponse.json({ error: error?.message ?? "Failed to load classroom session." }, { status: 500 });
+    return NextResponse.json({ error: "Failed to load classroom session." }, { status: 500 });
   }
 }
 
@@ -185,7 +185,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ session: payload }, { status: 201 });
   } catch (error: any) {
     console.error("POST /api/classroom-sessions error:", error);
-    return NextResponse.json({ error: error?.message ?? "Failed to create classroom session." }, { status: 500 });
+    return NextResponse.json({ error: "Failed to create classroom session." }, { status: 500 });
   }
 }
 
@@ -227,6 +227,6 @@ export async function PATCH(request: NextRequest) {
     return NextResponse.json({ session: payload }, { status: 200 });
   } catch (error: any) {
     console.error("PATCH /api/classroom-sessions error:", error);
-    return NextResponse.json({ error: error?.message ?? "Failed to update classroom session." }, { status: 500 });
+    return NextResponse.json({ error: "Failed to update classroom session." }, { status: 500 });
   }
 }

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,19 +1,38 @@
 import connectDB from "@/database/db";
 import Event from "@/database/eventSchema";
+import Session from "@/database/sessionSchema";
+import { getRequestActor, isPlainObject, requireAdmin } from "@/lib/server/apiAuthorization";
+import { resolveDataPrincipal } from "@/lib/server/classroomAuthorization";
 import { NextRequest, NextResponse } from "next/server";
 import mongoose from "mongoose";
-import Session from "@/database/sessionSchema";
+
+function normalizeEventProps(value: unknown) {
+  if (!isPlainObject(value)) return {};
+
+  return {
+    ...(typeof value.gameId === "string" ? { gameId: value.gameId.slice(0, 80) } : {}),
+    ...(typeof value.durationMs === "number" && Number.isFinite(value.durationMs)
+      ? { durationMs: value.durationMs }
+      : {}),
+    ...(typeof value.result === "string" ? { result: value.result.slice(0, 160) } : {}),
+    ...(typeof value.levelCompleted === "number" && Number.isInteger(value.levelCompleted)
+      ? { levelCompleted: value.levelCompleted }
+      : {}),
+    ...(typeof value.activityId === "string" ? { activityId: value.activityId.slice(0, 160) } : {}),
+    ...(typeof value.stageId === "string" ? { stageId: value.stageId.slice(0, 160) } : {}),
+  };
+}
 
 export async function GET(request: NextRequest) {
   try {
-    await connectDB();
+    const admin = requireAdmin(await getRequestActor());
+    if (!admin.ok) return admin.response;
 
     const { searchParams } = new URL(request.url);
     const anonUserId = searchParams.get("anonUserId");
     const event = searchParams.get("event");
     const sessionId = searchParams.get("sessionId");
-
-    const filter: Record<string, any> = {};
+    const filter: Record<string, unknown> = {};
 
     if (anonUserId) filter.anonUserId = anonUserId;
     if (event) filter.event = event;
@@ -24,13 +43,8 @@ export async function GET(request: NextRequest) {
       filter.sessionId = new mongoose.Types.ObjectId(sessionId);
     }
 
-    const sessionExists = await Session.exists({ _id: sessionId });
-    if (!sessionExists) {
-      return NextResponse.json({ error: "Session not found" }, { status: 404 });
-    }
-
+    await connectDB();
     const events = await Event.find(filter).sort({ ts: -1 });
-
     return NextResponse.json(events);
   } catch (error) {
     console.error("GET /api/events error:", error);
@@ -40,39 +54,56 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
+    const rawBody: unknown = await request.json().catch(() => null);
+    if (!isPlainObject(rawBody)) {
+      return NextResponse.json({ error: "Request body must be an object" }, { status: 400 });
+    }
+
+    const eventId = typeof rawBody.eventId === "string" ? rawBody.eventId.trim() : "";
+    const event = typeof rawBody.event === "string" ? rawBody.event.trim() : "";
+    const sessionId = typeof rawBody.sessionId === "string" ? rawBody.sessionId.trim() : "";
+    const classroomParticipantId =
+      typeof rawBody.classroomParticipantId === "string" ? rawBody.classroomParticipantId.trim() : undefined;
+    if (
+      !eventId ||
+      eventId.length > 200 ||
+      !event ||
+      event.length > 80 ||
+      !mongoose.Types.ObjectId.isValid(sessionId)
+    ) {
+      return NextResponse.json({ error: "Invalid eventId, event, or sessionId" }, { status: 400 });
+    }
+
     await connectDB();
+    const principal = await resolveDataPrincipal(request, await getRequestActor(), classroomParticipantId);
+    if (!principal.ok) return principal.response;
 
-    const body = await request.json();
-    const { eventId, ts, anonUserId, sessionId, event, props } = body;
-
-    if (!eventId || !anonUserId || !sessionId || !event) {
-      return NextResponse.json(
-        { error: "Missing required fields: eventId, anonUserId, sessionId, event" },
-        { status: 400 },
-      );
+    if (principal.value.classroom) {
+      if (principal.value.classroom.sessionId !== sessionId) {
+        return NextResponse.json({ error: "Session not found" }, { status: 404 });
+      }
+    } else {
+      const ownsSession = await Session.exists({ _id: sessionId, anonUserId: principal.value.ownerId });
+      if (!ownsSession) {
+        return NextResponse.json({ error: "Session not found" }, { status: 404 });
+      }
     }
 
-    if (!mongoose.Types.ObjectId.isValid(sessionId)) {
-      return NextResponse.json({ error: "Invalid sessionId" }, { status: 400 });
-    }
-
-    const newEvent = new Event({
+    const saved = await Event.create({
       eventId,
-      ts: ts ? new Date(ts) : new Date(),
-      anonUserId,
+      ts: new Date(),
+      anonUserId: principal.value.ownerId,
       sessionId: new mongoose.Types.ObjectId(sessionId),
       event,
-      props: props ?? {},
+      props: normalizeEventProps(rawBody.props),
     });
-
-    const saved = await newEvent.save();
 
     return NextResponse.json(saved, { status: 201 });
   } catch (error: any) {
-    if (error.code === 11000) {
-      return NextResponse.json({ error: "an event with this eventId already exists" }, { status: 409 });
+    if (error?.code === 11000) {
+      return NextResponse.json({ error: "An event with this eventId already exists" }, { status: 409 });
     }
     console.error("POST /api/events error:", error);
-    return NextResponse.json({ error: "failed to create an event" }, { status: 500 });
+    return NextResponse.json({ error: "Failed to create an event" }, { status: 500 });
   }
 }

--- a/src/app/api/example/route.ts
+++ b/src/app/api/example/route.ts
@@ -1,11 +1,15 @@
 import connectDB from "@/database/db";
 import { NextResponse } from "next/server";
+import { getRequestActor, requireAdmin } from "@/lib/server/apiAuthorization";
 
 /**
  * Example GET API route
  * @returns {message: string}
  */
 export async function GET() {
+  const admin = requireAdmin(await getRequestActor());
+  if (!admin.ok) return admin.response;
+
   await connectDB();
   return NextResponse.json({ message: "Hello from the API!" });
 }

--- a/src/app/api/gameData/[saveId]/route.test.ts
+++ b/src/app/api/gameData/[saveId]/route.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(),
+  connectDB: vi.fn(),
+  findOneAndUpdate: vi.fn(),
+  lean: vi.fn(),
+  resolveDataPrincipal: vi.fn(),
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({ auth: mocks.auth }));
+vi.mock("@/database/db", () => ({ default: mocks.connectDB }));
+vi.mock("@/database/gameDataSchema", () => ({
+  default: { findOneAndUpdate: mocks.findOneAndUpdate },
+}));
+vi.mock("@/lib/server/classroomAuthorization", () => ({
+  canEducatorReadClassroom: vi.fn(),
+  resolveDataPrincipal: mocks.resolveDataPrincipal,
+}));
+
+import { PATCH } from "@/app/api/gameData/[saveId]/route";
+
+describe("/api/gameData/:saveId ownership", () => {
+  beforeEach(() => {
+    mocks.auth.mockResolvedValue({ userId: "owner-1", sessionClaims: { role: "player" } });
+    mocks.resolveDataPrincipal.mockResolvedValue({
+      ok: true,
+      value: { ownerId: "owner-1", actor: { userId: "owner-1", role: "player" }, classroom: null },
+    });
+    mocks.lean.mockResolvedValue({ saveId: "save-1", userId: "owner-1" });
+    mocks.findOneAndUpdate.mockReturnValue({ lean: mocks.lean });
+  });
+
+  it("scopes updates to both save ID and server-derived owner", async () => {
+    const request = new NextRequest("http://localhost/api/gameData/save-1", {
+      method: "PATCH",
+      body: JSON.stringify({ completedLevels: [2], userId: "forged-user", gameId: "forged-game" }),
+      headers: { "content-type": "application/json" },
+    });
+
+    expect((await PATCH(request, { params: Promise.resolve({ saveId: "save-1" }) })).status).toBe(200);
+    expect(mocks.findOneAndUpdate).toHaveBeenCalledWith(
+      { saveId: "save-1", userId: "owner-1" },
+      expect.objectContaining({
+        $addToSet: { completedLevels: { $each: [2] } },
+      }),
+      { new: true, runValidators: true },
+    );
+  });
+
+  it("rejects updates containing no mutable progress fields", async () => {
+    const request = new NextRequest("http://localhost/api/gameData/save-1", {
+      method: "PATCH",
+      body: JSON.stringify({ userId: "forged-user", gameId: "forged-game" }),
+      headers: { "content-type": "application/json" },
+    });
+
+    expect((await PATCH(request, { params: Promise.resolve({ saveId: "save-1" }) })).status).toBe(400);
+    expect(mocks.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/gameData/[saveId]/route.ts
+++ b/src/app/api/gameData/[saveId]/route.ts
@@ -1,72 +1,85 @@
 import connectDB from "@/database/db";
-import { auth } from "@clerk/nextjs/server";
 import GameData from "@/database/gameDataSchema";
-import { NextResponse, NextRequest } from "next/server";
+import { getRequestActor, isPlainObject } from "@/lib/server/apiAuthorization";
+import { canEducatorReadClassroom, DataPrincipal, resolveDataPrincipal } from "@/lib/server/classroomAuthorization";
+import { parseGameDataProgress } from "@/lib/server/gameDataValidation";
+import { ApiInputError } from "@/lib/server/apiErrors";
+import { NextRequest, NextResponse } from "next/server";
 
-function isIntegerArray(value: unknown): value is number[] {
-  return Array.isArray(value) && value.every((item) => typeof item === "number" && Number.isInteger(item));
+type GameDataRecord = {
+  userId: string;
+  classroomSessionId?: string | null;
+};
+
+async function canReadGameData(principal: DataPrincipal, record: GameDataRecord) {
+  return (
+    record.userId === principal.ownerId ||
+    principal.actor.role === "admin" ||
+    (await canEducatorReadClassroom(principal.actor, record.classroomSessionId))
+  );
 }
 
-function isNonEmptyStringArray(value: unknown): value is string[] {
-  return Array.isArray(value) && value.every((item) => typeof item === "string" && item.length > 0);
-}
-
-export async function GET(_req: Request, { params }: { params: Promise<{ saveId: string }> }) {
-  const { userId } = await auth();
-  await connectDB();
-  const { saveId } = await params;
-
-  const data = await GameData.findOne({ saveId, userId }).lean();
-  if (!data) {
-    return NextResponse.json({ error: "Game data not found" }, { status: 404 });
-  }
-  return NextResponse.json(data, { status: 200 });
-}
-
-export async function PATCH(req: NextRequest, { params }: { params: Promise<{ saveId: string }> }) {
+export async function GET(request: NextRequest, { params }: { params: Promise<{ saveId: string }> }) {
   try {
     await connectDB();
+    const principal = await resolveDataPrincipal(request, await getRequestActor());
+    if (!principal.ok) return principal.response;
+
     const { saveId } = await params;
-    const changes = await req.json();
-    if (!changes || typeof changes !== "object" || Array.isArray(changes)) {
-      return NextResponse.json({ error: "Invalid patch" }, { status: 400 });
+    const data = await GameData.findOne({ saveId }).lean<GameDataRecord | null>();
+    if (!data || !(await canReadGameData(principal.value, data))) {
+      return NextResponse.json({ error: "Game data not found" }, { status: 404 });
     }
 
-    const patch = changes as Record<string, unknown>;
-    const hasCompletedLevels = Object.prototype.hasOwnProperty.call(patch, "completedLevels");
-    const hasCompletedStageIds = Object.prototype.hasOwnProperty.call(patch, "completedStageIds");
+    return NextResponse.json(data, { status: 200 });
+  } catch (error) {
+    console.error("GET /api/gameData/:saveId error:", error);
+    return NextResponse.json({ error: "Failed to load game data" }, { status: 500 });
+  }
+}
 
-    if (hasCompletedLevels && !isIntegerArray(patch.completedLevels)) {
-      return NextResponse.json({ error: "completedLevels must be an array of integers" }, { status: 400 });
-    }
-    if (hasCompletedStageIds && !isNonEmptyStringArray(patch.completedStageIds)) {
-      return NextResponse.json({ error: "completedStageIds must be an array of non-empty strings" }, { status: 400 });
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ saveId: string }> }) {
+  try {
+    const rawBody: unknown = await request.json().catch(() => null);
+    if (!isPlainObject(rawBody)) {
+      return NextResponse.json({ error: "Request body must be an object" }, { status: 400 });
     }
 
-    const { completedLevels, completedStageIds, ...fieldsToSet } = patch;
-    const update: Record<string, unknown> = {};
+    const progress = parseGameDataProgress(rawBody);
+    const claimedParticipantId =
+      typeof rawBody.classroomParticipantId === "string" ? rawBody.classroomParticipantId.trim() : undefined;
+
+    await connectDB();
+    const principal = await resolveDataPrincipal(request, await getRequestActor(), claimedParticipantId);
+    if (!principal.ok) return principal.response;
+
+    const update: Record<string, unknown> = { $set: { lastUpdated: new Date() } };
     const completionAdditions: Record<string, unknown> = {};
-
-    if (Object.keys(fieldsToSet).length > 0) {
-      update.$set = fieldsToSet;
+    if (progress.completedLevels) {
+      completionAdditions.completedLevels = { $each: progress.completedLevels };
     }
-    if (hasCompletedLevels) {
-      completionAdditions.completedLevels = { $each: Array.from(new Set(completedLevels as number[])) };
-    }
-    if (hasCompletedStageIds) {
-      completionAdditions.completedStageIds = { $each: Array.from(new Set(completedStageIds as string[])) };
+    if (progress.completedStageIds) {
+      completionAdditions.completedStageIds = { $each: progress.completedStageIds };
     }
     if (Object.keys(completionAdditions).length > 0) {
       update.$addToSet = completionAdditions;
     }
 
-    const updated = await GameData.findOneAndUpdate({ saveId }, update, { new: true, runValidators: true }).lean();
+    const { saveId } = await params;
+    const updated = await GameData.findOneAndUpdate({ saveId, userId: principal.value.ownerId }, update, {
+      new: true,
+      runValidators: true,
+    }).lean();
     if (!updated) {
-      return NextResponse.json({ error: "Save not found" }, { status: 404 });
+      return NextResponse.json({ error: "Game data not found" }, { status: 404 });
     }
+
     return NextResponse.json(updated, { status: 200 });
-  } catch (err: any) {
-    console.error("Server error", err);
-    return NextResponse.json({ error: err.message }, { status: 500 });
+  } catch (error) {
+    if (error instanceof ApiInputError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    console.error("PATCH /api/gameData/:saveId error:", error);
+    return NextResponse.json({ error: "Failed to update game data" }, { status: 500 });
   }
 }

--- a/src/app/api/gameData/route.test.ts
+++ b/src/app/api/gameData/route.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(),
+  connectDB: vi.fn(),
+  create: vi.fn(),
+  find: vi.fn(),
+  lean: vi.fn(),
+  resolveDataPrincipal: vi.fn(),
+  sort: vi.fn(),
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({ auth: mocks.auth }));
+vi.mock("@/database/db", () => ({ default: mocks.connectDB }));
+vi.mock("@/database/gameDataSchema", () => ({
+  default: {
+    create: mocks.create,
+    find: mocks.find,
+  },
+}));
+vi.mock("@/lib/server/classroomAuthorization", () => ({
+  resolveDataPrincipal: mocks.resolveDataPrincipal,
+}));
+
+import { GET, POST } from "@/app/api/gameData/route";
+
+describe("/api/gameData authorization", () => {
+  beforeEach(() => {
+    mocks.lean.mockResolvedValue([]);
+    mocks.sort.mockReturnValue({ lean: mocks.lean });
+    mocks.find.mockReturnValue({ sort: mocks.sort });
+  });
+
+  it("denies anonymous and non-admin aggregate reads", async () => {
+    mocks.auth.mockResolvedValueOnce({ userId: null, sessionClaims: null });
+    expect((await GET()).status).toBe(401);
+
+    mocks.auth.mockResolvedValueOnce({ userId: "player-1", sessionClaims: { role: "player" } });
+    expect((await GET()).status).toBe(403);
+    expect(mocks.find).not.toHaveBeenCalled();
+  });
+
+  it("allows administrators to list game data", async () => {
+    mocks.auth.mockResolvedValue({ userId: "admin-1", sessionClaims: { role: "admin" } });
+    expect((await GET()).status).toBe(200);
+    expect(mocks.find).toHaveBeenCalledWith({});
+  });
+
+  it("derives save ownership from the authorized principal", async () => {
+    mocks.auth.mockResolvedValue({ userId: "real-user", sessionClaims: { role: "player" } });
+    mocks.resolveDataPrincipal.mockResolvedValue({
+      ok: true,
+      value: { ownerId: "real-user", actor: { userId: "real-user", role: "player" }, classroom: null },
+    });
+    mocks.create.mockImplementation(async (value) => value);
+
+    const request = new NextRequest("http://localhost/api/gameData", {
+      method: "POST",
+      body: JSON.stringify({
+        saveId: "save-1",
+        saveVersion: 1,
+        gameVersion: "1.0.0",
+        gameId: "PenguinRun",
+        completedLevels: [1],
+        userId: "forged-user",
+        classroomSessionId: "forged-session",
+      }),
+      headers: { "content-type": "application/json" },
+    });
+
+    expect((await POST(request)).status).toBe(201);
+    expect(mocks.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "real-user",
+        classroomSessionId: null,
+        classroomParticipantId: null,
+      }),
+    );
+    expect(mocks.create.mock.calls[0][0]).not.toMatchObject({ userId: "forged-user" });
+  });
+});

--- a/src/app/api/gameData/route.ts
+++ b/src/app/api/gameData/route.ts
@@ -1,28 +1,58 @@
 import connectDB from "@/database/db";
 import GameData from "@/database/gameDataSchema";
-import { NextResponse } from "next/server";
+import { getRequestActor, isPlainObject, requireAdmin } from "@/lib/server/apiAuthorization";
+import { resolveDataPrincipal } from "@/lib/server/classroomAuthorization";
+import { parseNewGameData } from "@/lib/server/gameDataValidation";
+import { ApiInputError } from "@/lib/server/apiErrors";
+import { NextRequest, NextResponse } from "next/server";
 
 export async function GET() {
   try {
-    await connectDB();
+    const admin = requireAdmin(await getRequestActor());
+    if (!admin.ok) return admin.response;
 
+    await connectDB();
     const gameData = await GameData.find({}).sort({ lastUpdated: -1 }).lean();
     return NextResponse.json(gameData, { status: 200 });
-  } catch (err: any) {
-    console.error("Caught an error", err);
-    return NextResponse.json({ error: err.message }, { status: 400 });
+  } catch (error) {
+    console.error("GET /api/gameData error:", error);
+    return NextResponse.json({ error: "Failed to load game data" }, { status: 500 });
   }
 }
 
-export async function POST(req: Request) {
+export async function POST(request: NextRequest) {
   try {
-    await connectDB();
+    const rawBody: unknown = await request.json().catch(() => null);
+    if (!isPlainObject(rawBody)) {
+      return NextResponse.json({ error: "Request body must be an object" }, { status: 400 });
+    }
 
-    const body = await req.json();
-    const gamedata = await GameData.create(body);
-    return NextResponse.json(gamedata, { status: 201 });
-  } catch (err: any) {
-    console.error("Caught an error", err);
-    return NextResponse.json({ error: err.message }, { status: 400 });
+    const input = parseNewGameData(rawBody);
+    const claimedParticipantId =
+      typeof rawBody.classroomParticipantId === "string" ? rawBody.classroomParticipantId.trim() : undefined;
+
+    await connectDB();
+    const principal = await resolveDataPrincipal(request, await getRequestActor(), claimedParticipantId);
+    if (!principal.ok) return principal.response;
+
+    const gameData = await GameData.create({
+      ...input,
+      userId: principal.value.ownerId,
+      lastUpdated: new Date(),
+      classroomSessionId: principal.value.classroom?.sessionId ?? null,
+      classroomParticipantId: principal.value.classroom?.participantId ?? null,
+      studentDisplayName: principal.value.classroom?.displayName ?? null,
+    });
+
+    return NextResponse.json(gameData, { status: 201 });
+  } catch (error: any) {
+    if (error?.code === 11000) {
+      return NextResponse.json({ error: "A save with that ID already exists" }, { status: 409 });
+    }
+    if (error instanceof ApiInputError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
+    console.error("POST /api/gameData error:", error);
+    return NextResponse.json({ error: "Failed to create game data" }, { status: 500 });
   }
 }

--- a/src/app/api/quiz/[id]/route.ts
+++ b/src/app/api/quiz/[id]/route.ts
@@ -3,6 +3,9 @@ import Quiz from "@/database/quizSchema";
 import quizData from "@/data/quiz.json";
 import mongoose from "mongoose";
 import { NextRequest, NextResponse } from "next/server";
+import { getRequestActor } from "@/lib/server/apiAuthorization";
+import { canEducatorReadClassroom, DataPrincipal, resolveDataPrincipal } from "@/lib/server/classroomAuthorization";
+import { ApiInputError } from "@/lib/server/apiErrors";
 
 type QuizOption = {
   id: string;
@@ -47,6 +50,19 @@ function getQuizLookupFilter(id: string) {
   return { quizId: id };
 }
 
+type QuizRecord = {
+  clerkId: string;
+  classroomSessionId?: string | null;
+};
+
+async function canReadQuiz(principal: DataPrincipal, quiz: QuizRecord) {
+  return (
+    quiz.clerkId === principal.ownerId ||
+    principal.actor.role === "admin" ||
+    (await canEducatorReadClassroom(principal.actor, quiz.classroomSessionId))
+  );
+}
+
 function isObject(value: unknown): value is Record<string, unknown> {
   // Narrow unknown JSON input to a plain object before reading any fields.
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -55,7 +71,7 @@ function isObject(value: unknown): value is Record<string, unknown> {
 function parseNumber(value: unknown, field: string): number {
   // Enforce numeric fields early so invalid payloads fail with a clear 400 message.
   if (typeof value !== "number" || Number.isNaN(value)) {
-    throw new Error(`${field} must be a number`);
+    throw new ApiInputError(`${field} must be a number`);
   }
   return value;
 }
@@ -63,7 +79,7 @@ function parseNumber(value: unknown, field: string): number {
 function parseBoolean(value: unknown, field: string): boolean {
   // Keep boolean flags strict to avoid accepting string/number lookalikes.
   if (typeof value !== "boolean") {
-    throw new Error(`${field} must be a boolean`);
+    throw new ApiInputError(`${field} must be a boolean`);
   }
   return value;
 }
@@ -71,7 +87,7 @@ function parseBoolean(value: unknown, field: string): boolean {
 function parseString(value: unknown, field: string): string {
   // Require non-empty strings for identity fields like quizId/clerkId.
   if (typeof value !== "string" || value.trim().length === 0) {
-    throw new Error(`${field} must be a non-empty string`);
+    throw new ApiInputError(`${field} must be a non-empty string`);
   }
   return value.trim();
 }
@@ -82,7 +98,7 @@ function extractAnswerOptions(rawOptions: unknown, fallbackOptions: QuizOption[]
   }
 
   if (!Array.isArray(rawOptions)) {
-    throw new Error(`answerOptions/options must be an array for questionId=${questionId}`);
+    throw new ApiInputError(`answerOptions/options must be an array for questionId=${questionId}`);
   }
 
   const normalizedOptions = rawOptions.map((option) => {
@@ -94,7 +110,7 @@ function extractAnswerOptions(rawOptions: unknown, fallbackOptions: QuizOption[]
       return option.text.trim();
     }
 
-    throw new Error(`Invalid option format for questionId=${questionId}`);
+    throw new ApiInputError(`Invalid option format for questionId=${questionId}`);
   });
 
   return normalizedOptions;
@@ -115,12 +131,12 @@ function normalizeQuestionResults(
   fieldName: string,
 ) {
   if (!Array.isArray(rawResults)) {
-    throw new Error(`${fieldName} must be an array`);
+    throw new ApiInputError(`${fieldName} must be an array`);
   }
 
   return rawResults.map((rawResult) => {
     if (!isObject(rawResult)) {
-      throw new Error(`${fieldName} contains an invalid question result`);
+      throw new ApiInputError(`${fieldName} contains an invalid question result`);
     }
 
     const incoming = rawResult as IncomingQuestionResult;
@@ -128,7 +144,7 @@ function normalizeQuestionResults(
     const questionDefinition = questionMap.get(questionId);
 
     if (!questionDefinition) {
-      throw new Error(`Unknown questionId=${questionId} in ${fieldName}`);
+      throw new ApiInputError(`Unknown questionId=${questionId} in ${fieldName}`);
     }
 
     const questionText =
@@ -150,7 +166,7 @@ function normalizeQuestionResults(
         : optionIdToText(incoming.selectedOptionId, questionDefinition);
 
     if (!selectedAnswer) {
-      throw new Error(`selectedAnswer or selectedOptionId is required for questionId=${questionId}`);
+      throw new ApiInputError(`selectedAnswer or selectedOptionId is required for questionId=${questionId}`);
     }
 
     const correctAnswer =
@@ -180,13 +196,16 @@ function scoreFromResults(results: { isCorrect: boolean }[]) {
 
 // GET /api/quiz/:id
 // Finds a quiz by ObjectId or quizId
-export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
     await connectDB();
 
-    const quiz = await Quiz.findOne(getQuizLookupFilter(id)).lean();
-    if (!quiz) {
+    const principal = await resolveDataPrincipal(request, await getRequestActor());
+    if (!principal.ok) return principal.response;
+
+    const quiz = await Quiz.findOne(getQuizLookupFilter(id)).lean<QuizRecord | null>();
+    if (!quiz || !(await canReadQuiz(principal.value, quiz))) {
       return NextResponse.json({ error: "Quiz not found" }, { status: 404 });
     }
 
@@ -194,7 +213,7 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
   } catch (err: any) {
     // Unexpected lookup failures are treated as server errors.
     console.error("GET /api/quiz/:id error:", err);
-    return NextResponse.json({ error: err.message }, { status: 500 });
+    return NextResponse.json({ error: "Failed to load quiz" }, { status: 500 });
   }
 }
 
@@ -203,7 +222,7 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
 export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
-    const rawBody: unknown = await req.json();
+    const rawBody: unknown = await req.json().catch(() => null);
     // Reject non-object payloads before any field-level parsing.
     if (!isObject(rawBody)) {
       return NextResponse.json({ error: "Request body must be an object" }, { status: 400 });
@@ -211,8 +230,6 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
 
     const changes: Record<string, unknown> = {};
 
-    if (rawBody.quizId !== undefined) changes.quizId = parseString(rawBody.quizId, "quizId");
-    if (rawBody.clerkId !== undefined) changes.clerkId = parseString(rawBody.clerkId, "clerkId");
     if (rawBody.statesOfMatterScoreBefore !== undefined) {
       changes.statesOfMatterScoreBefore = parseNumber(rawBody.statesOfMatterScoreBefore, "statesOfMatterScoreBefore");
     }
@@ -258,8 +275,16 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
 
     await connectDB();
 
+    const principal = await resolveDataPrincipal(req, await getRequestActor());
+    if (!principal.ok) return principal.response;
+
+    const existingQuiz = await Quiz.findOne(getQuizLookupFilter(id)).lean<QuizRecord | null>();
+    if (!existingQuiz || (existingQuiz.clerkId !== principal.value.ownerId && principal.value.actor.role !== "admin")) {
+      return NextResponse.json({ error: "Quiz not found" }, { status: 404 });
+    }
+
     const updatedQuiz = await Quiz.findOneAndUpdate(
-      getQuizLookupFilter(id),
+      { ...getQuizLookupFilter(id), clerkId: existingQuiz.clerkId },
       { $set: changes },
       { new: true, runValidators: true },
     ).lean();
@@ -270,9 +295,11 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
     }
 
     return NextResponse.json(updatedQuiz, { status: 200 });
-  } catch (err: any) {
-    // Validation/parsing and DB update errors are surfaced as bad requests for the caller.
+  } catch (err) {
+    if (err instanceof ApiInputError) {
+      return NextResponse.json({ error: err.message }, { status: 400 });
+    }
     console.error("PUT /api/quiz/:id error:", err);
-    return NextResponse.json({ error: err.message }, { status: 400 });
+    return NextResponse.json({ error: "Failed to update quiz" }, { status: 500 });
   }
 }

--- a/src/app/api/quiz/route.ts
+++ b/src/app/api/quiz/route.ts
@@ -1,15 +1,11 @@
 import connectDB from "@/database/db";
 import User from "@/database/userSchema";
 import Quiz from "@/database/quizSchema";
-import ClassroomParticipant from "@/database/classroomParticipantSchema";
-import { auth } from "@clerk/nextjs/server";
 import { NextRequest, NextResponse } from "next/server";
 import mongoose from "mongoose";
-
-type QuizOption = {
-  id: string;
-  text: string;
-};
+import { getRequestActor, requireAdmin } from "@/lib/server/apiAuthorization";
+import { resolveDataPrincipal } from "@/lib/server/classroomAuthorization";
+import { ApiInputError } from "@/lib/server/apiErrors";
 
 type QuizQuestionResultInput = {
   questionId?: unknown;
@@ -26,33 +22,33 @@ function isObject(value: unknown): value is Record<string, unknown> {
 
 function parseNumber(value: unknown, field: string): number {
   if (typeof value !== "number" || Number.isNaN(value)) {
-    throw new Error(`${field} must be a number`);
+    throw new ApiInputError(`${field} must be a number`);
   }
   return value;
 }
 
 function parseString(value: unknown, field: string): string {
   if (typeof value !== "string" || value.trim().length === 0) {
-    throw new Error(`${field} must be a non-empty string`);
+    throw new ApiInputError(`${field} must be a non-empty string`);
   }
   return value.trim();
 }
 
 function parseBoolean(value: unknown, field: string): boolean {
   if (typeof value !== "boolean") {
-    throw new Error(`${field} must be a boolean`);
+    throw new ApiInputError(`${field} must be a boolean`);
   }
   return value;
 }
 
 function normalizeQuestionResults(rawResults: unknown, fieldName: string) {
   if (!Array.isArray(rawResults)) {
-    throw new Error(`${fieldName} must be an array`);
+    throw new ApiInputError(`${fieldName} must be an array`);
   }
 
   return rawResults.map((rawResult) => {
     if (!isObject(rawResult)) {
-      throw new Error(`${fieldName} contains an invalid question result`);
+      throw new ApiInputError(`${fieldName} contains an invalid question result`);
     }
 
     const incoming = rawResult as QuizQuestionResultInput;
@@ -72,29 +68,27 @@ function normalizeQuestionResults(rawResults: unknown, fieldName: string) {
 }
 
 // GET /api/quiz
-// Fetch all quiz documents
-export async function GET(req: NextRequest) {
+// Fetch all quiz documents for administrators.
+export async function GET() {
   try {
-    await connectDB();
+    const admin = requireAdmin(await getRequestActor());
+    if (!admin.ok) return admin.response;
 
-    const clerkId = req.nextUrl.searchParams.get("clerkId")?.trim();
-    const filter = clerkId ? { clerkId } : {};
-    const quizzes = await Quiz.find(filter).sort({ createdAt: -1 }).lean();
+    await connectDB();
+    const quizzes = await Quiz.find({}).sort({ createdAt: -1 }).lean();
     return NextResponse.json(quizzes, { status: 200 });
   } catch (err: any) {
     // Any DB/query failure is returned as a 500 so callers can treat this as a server-side error.
     console.error("GET /api/quiz error:", err);
-    return NextResponse.json({ error: err.message }, { status: 500 });
+    return NextResponse.json({ error: "Failed to load quizzes" }, { status: 500 });
   }
 }
 
 // POST /api/quiz
 // Creates a quiz record for the signed-in user or updates the existing one.
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
   try {
-    const { userId } = await auth();
-
-    const rawBody: unknown = await req.json();
+    const rawBody: unknown = await req.json().catch(() => null);
     if (!isObject(rawBody)) {
       return NextResponse.json({ error: "Request body must be an object" }, { status: 400 });
     }
@@ -133,40 +127,17 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "No valid fields provided for update" }, { status: 400 });
     }
 
-    await connectDB();
-
     const classroomParticipantId =
       typeof rawBody.classroomParticipantId === "string" ? rawBody.classroomParticipantId.trim() : "";
-    const classroomSessionId = typeof rawBody.classroomSessionId === "string" ? rawBody.classroomSessionId.trim() : "";
-    const studentDisplayName = typeof rawBody.studentDisplayName === "string" ? rawBody.studentDisplayName.trim() : "";
+    await connectDB();
+    const principal = await resolveDataPrincipal(req, await getRequestActor(), classroomParticipantId || undefined);
+    if (!principal.ok) return principal.response;
 
-    let recordKey = userId ?? "";
-    let resolvedStudentDisplayName = studentDisplayName;
-
-    if (classroomParticipantId) {
-      const participant = await ClassroomParticipant.findById(classroomParticipantId).lean<{
-        _id: mongoose.Types.ObjectId;
-        sessionId: mongoose.Types.ObjectId;
-        displayName: string;
-      } | null>();
-
-      if (!participant) {
-        return NextResponse.json({ error: "Classroom participant not found." }, { status: 404 });
-      }
-
-      if (classroomSessionId && String(participant.sessionId) !== classroomSessionId) {
-        return NextResponse.json({ error: "Classroom participant does not belong to this session." }, { status: 400 });
-      }
-
-      recordKey = `participant:${classroomParticipantId}`;
-      resolvedStudentDisplayName = resolvedStudentDisplayName || participant.displayName;
-      updates.classroomParticipantId = classroomParticipantId;
-      updates.classroomSessionId = classroomSessionId || String(participant.sessionId);
-      updates.studentDisplayName = resolvedStudentDisplayName;
-    }
-
-    if (!recordKey) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    const recordKey = principal.value.ownerId;
+    if (principal.value.classroom) {
+      updates.classroomParticipantId = principal.value.classroom.participantId;
+      updates.classroomSessionId = principal.value.classroom.sessionId;
+      updates.studentDisplayName = principal.value.classroom.displayName;
     }
 
     const quiz = await Quiz.findOneAndUpdate(
@@ -185,13 +156,25 @@ export async function POST(req: Request) {
       },
     );
 
-    if (userId && quiz?._id && mongoose.Types.ObjectId.isValid(String(quiz._id))) {
-      await User.findOneAndUpdate({ clerkId: userId }, { $set: { quizId: quiz._id } }, { runValidators: true });
+    if (
+      principal.value.actor.userId &&
+      !principal.value.classroom &&
+      quiz?._id &&
+      mongoose.Types.ObjectId.isValid(String(quiz._id))
+    ) {
+      await User.findOneAndUpdate(
+        { clerkId: principal.value.actor.userId },
+        { $set: { quizId: quiz._id } },
+        { runValidators: true },
+      );
     }
 
     return NextResponse.json(quiz, { status: 200 });
-  } catch (err: any) {
+  } catch (err) {
+    if (err instanceof ApiInputError) {
+      return NextResponse.json({ error: err.message }, { status: 400 });
+    }
     console.error("POST /api/quiz error:", err);
-    return NextResponse.json({ error: err.message }, { status: 400 });
+    return NextResponse.json({ error: "Failed to save quiz" }, { status: 500 });
   }
 }

--- a/src/app/api/sessions/[sessionId]/route.ts
+++ b/src/app/api/sessions/[sessionId]/route.ts
@@ -1,92 +1,81 @@
 import connectDB from "@/database/db";
 import Session from "@/database/sessionSchema";
+import { getRequestActor, isPlainObject, requireSignedIn } from "@/lib/server/apiAuthorization";
 import { NextRequest, NextResponse } from "next/server";
 import mongoose from "mongoose";
-// GET and PATCH routes for sessions
 
-/**
- * GET /api/sessions/:sessionId
- * Fetch a session by ID
- */
-export async function GET(request: NextRequest, { params }: { params: Promise<{ sessionId: string }> }) {
+async function getAuthorizedSession(sessionId: string) {
+  const signedIn = requireSignedIn(await getRequestActor());
+  if (!signedIn.ok) return signedIn;
+
+  const session = await Session.findById(sessionId);
+  if (!session || (signedIn.value.role !== "admin" && session.anonUserId !== signedIn.value.userId)) {
+    return { ok: false as const, response: NextResponse.json({ error: "Session not found" }, { status: 404 }) };
+  }
+
+  return { ok: true as const, value: session };
+}
+
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ sessionId: string }> }) {
   try {
-    await connectDB();
-
     const { sessionId } = await params;
-
     if (!mongoose.Types.ObjectId.isValid(sessionId)) {
       return NextResponse.json({ error: "Invalid session ID" }, { status: 400 });
     }
 
-    const session = await Session.findById(sessionId);
-
-    if (!session) {
-      return NextResponse.json({ error: "Session not found" }, { status: 404 });
-    }
-
-    return NextResponse.json({
-      _id: session._id,
-      anonUserId: session.anonUserId,
-      gameId: session.gameId ?? null,
-      startedAt: session.startedAt,
-      endedAt: session.endedAt,
-      durationMs: session.durationMs,
-    });
+    await connectDB();
+    const authorized = await getAuthorizedSession(sessionId);
+    if (!authorized.ok) return authorized.response;
+    return NextResponse.json(authorized.value);
   } catch (error) {
     console.error("GET /api/sessions/:sessionId error:", error);
     return NextResponse.json({ error: "Failed to fetch session" }, { status: 500 });
   }
 }
 
-/**
- * PATCH /api/sessions/:sessionId
- * Update a session (e.g., end it by setting endedAt and durationMs)
- * Body: { endedAt?: Date, durationMs?: number } or empty to auto-end
- */
 export async function PATCH(request: NextRequest, { params }: { params: Promise<{ sessionId: string }> }) {
   try {
-    await connectDB();
-
     const { sessionId } = await params;
-
     if (!mongoose.Types.ObjectId.isValid(sessionId)) {
       return NextResponse.json({ error: "Invalid session ID" }, { status: 400 });
     }
 
-    const session = await Session.findById(sessionId);
-
-    if (!session) {
-      return NextResponse.json({ error: "Session not found" }, { status: 404 });
+    const rawBody: unknown = await request.json().catch(() => ({}));
+    if (!isPlainObject(rawBody)) {
+      return NextResponse.json({ error: "Request body must be an object" }, { status: 400 });
     }
 
-    const body = await request.json().catch(() => ({}));
+    await connectDB();
+    const authorized = await getAuthorizedSession(sessionId);
+    if (!authorized.ok) return authorized.response;
 
-    // If body is empty or only endedAt/durationMs, allow update
     const update: { endedAt?: Date; durationMs?: number } = {};
-
-    if (body.endedAt !== undefined) {
-      update.endedAt = typeof body.endedAt === "string" ? new Date(body.endedAt) : body.endedAt;
-    } else if (Object.keys(body).length === 0 || body.endSession) {
-      // Auto-end: set endedAt to now and calculate duration
-      const endedAt = new Date();
-      update.endedAt = endedAt;
-      update.durationMs = endedAt.getTime() - session.startedAt.getTime();
+    if (rawBody.endedAt !== undefined) {
+      if (typeof rawBody.endedAt !== "string" || Number.isNaN(Date.parse(rawBody.endedAt))) {
+        return NextResponse.json({ error: "endedAt must be a valid date string" }, { status: 400 });
+      }
+      update.endedAt = new Date(rawBody.endedAt);
+    } else if (Object.keys(rawBody).length === 0 || rawBody.endSession === true) {
+      update.endedAt = new Date();
+      update.durationMs = update.endedAt.getTime() - authorized.value.startedAt.getTime();
     }
 
-    if (body.durationMs !== undefined) {
-      update.durationMs = Number(body.durationMs);
+    if (rawBody.durationMs !== undefined) {
+      if (typeof rawBody.durationMs !== "number" || !Number.isFinite(rawBody.durationMs) || rawBody.durationMs < 0) {
+        return NextResponse.json({ error: "durationMs must be a non-negative number" }, { status: 400 });
+      }
+      update.durationMs = rawBody.durationMs;
+    }
+    if (Object.keys(update).length === 0) {
+      return NextResponse.json({ error: "No valid fields provided for update" }, { status: 400 });
     }
 
-    const updatedSession = await Session.findByIdAndUpdate(sessionId, { $set: update }, { new: true });
-
-    return NextResponse.json({
-      _id: updatedSession!._id,
-      anonUserId: updatedSession!.anonUserId,
-      gameId: updatedSession!.gameId ?? null,
-      startedAt: updatedSession!.startedAt,
-      endedAt: updatedSession!.endedAt,
-      durationMs: updatedSession!.durationMs,
-    });
+    const updatedSession = await Session.findByIdAndUpdate(
+      sessionId,
+      { $set: update },
+      { new: true, runValidators: true },
+    );
+    return NextResponse.json(updatedSession);
   } catch (error) {
     console.error("PATCH /api/sessions/:sessionId error:", error);
     return NextResponse.json({ error: "Failed to update session" }, { status: 500 });

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -1,5 +1,6 @@
 import connectDB from "@/database/db";
 import Session from "@/database/sessionSchema";
+import { getRequestActor, isPlainObject, requireAdmin, requireSignedIn } from "@/lib/server/apiAuthorization";
 import { NextRequest, NextResponse } from "next/server";
 
 const VALID_GAME_IDS = new Set(["penguinRunGame", "statesOfMatterGame"]);
@@ -10,26 +11,18 @@ function getPeriodStart(period: string | null): Date | null {
   const now = Date.now();
   if (period === "7d") return new Date(now - 7 * 24 * 60 * 60 * 1000);
   if (period === "30d") return new Date(now - 30 * 24 * 60 * 60 * 1000);
-
   return null;
 }
 
-/**
- * GET /api/sessions
- * Fetch all sessions
- * Query params:
- * - gameId?: penguinRunGame | statesOfMatterGame
- * - period?: 7d | 30d | all
- */
 export async function GET(request: NextRequest) {
   try {
-    await connectDB();
+    const admin = requireAdmin(await getRequestActor());
+    if (!admin.ok) return admin.response;
 
     const { searchParams } = new URL(request.url);
     const gameId = searchParams.get("gameId");
     const period = searchParams.get("period");
     const startedAfter = getPeriodStart(period);
-
     const filter: Record<string, unknown> = {};
 
     if (gameId) {
@@ -41,70 +34,45 @@ export async function GET(request: NextRequest) {
       }
       filter.gameId = gameId;
     }
-
     if (period && !["7d", "30d", "all"].includes(period)) {
       return NextResponse.json({ error: "period must be one of: 7d, 30d, all" }, { status: 400 });
     }
+    if (startedAfter) filter.startedAt = { $gte: startedAfter };
 
-    if (startedAfter) {
-      filter.startedAt = { $gte: startedAfter };
-    }
-
+    await connectDB();
     const sessions = await Session.find(filter).sort({ startedAt: -1 });
-
-    const serialized = sessions.map((session) => ({
-      _id: session._id,
-      anonUserId: session.anonUserId,
-      gameId: session.gameId ?? null,
-      startedAt: session.startedAt,
-      endedAt: session.endedAt,
-      durationMs: session.durationMs,
-    }));
-
-    return NextResponse.json(serialized);
+    return NextResponse.json(sessions);
   } catch (error) {
     console.error("GET /api/sessions error:", error);
     return NextResponse.json({ error: "Failed to fetch sessions" }, { status: 500 });
   }
 }
 
-/**
- * POST /api/sessions
- * Create a new session
- * Body: { anonUserId: string, gameId?: "penguinRunGame" | "statesOfMatterGame" }
- */
 export async function POST(request: NextRequest) {
   try {
-    await connectDB();
+    const signedIn = requireSignedIn(await getRequestActor());
+    if (!signedIn.ok) return signedIn.response;
 
-    const body = await request.json();
-    const { anonUserId, gameId } = body;
-
-    if (!anonUserId || typeof anonUserId !== "string") {
-      return NextResponse.json({ error: "anonUserId is required and must be a string" }, { status: 400 });
+    const rawBody: unknown = await request.json();
+    if (!isPlainObject(rawBody)) {
+      return NextResponse.json({ error: "Request body must be an object" }, { status: 400 });
     }
 
+    const gameId = rawBody.gameId;
     if (gameId !== undefined && (typeof gameId !== "string" || !VALID_GAME_IDS.has(gameId))) {
       return NextResponse.json({ error: "gameId must be one of: penguinRunGame, statesOfMatterGame" }, { status: 400 });
     }
 
-    const startedAt = new Date();
+    await connectDB();
     const session = await Session.create({
-      anonUserId,
+      anonUserId: signedIn.value.userId,
       gameId: gameId ?? null,
-      startedAt,
+      startedAt: new Date(),
       endedAt: null,
       durationMs: 0,
     });
 
-    return NextResponse.json({
-      _id: session._id,
-      anonUserId: session.anonUserId,
-      gameId: session.gameId ?? null,
-      startedAt: session.startedAt,
-      endedAt: session.endedAt,
-      durationMs: session.durationMs,
-    });
+    return NextResponse.json(session, { status: 201 });
   } catch (error) {
     console.error("POST /api/sessions error:", error);
     return NextResponse.json({ error: "Failed to create session" }, { status: 500 });

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -1,46 +1,65 @@
 import connectDB from "@/database/db";
-import { NextResponse, NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import User from "@/database/userSchema";
 import mongoose from "mongoose";
+import { getRequestActor, isPlainObject, requireAdmin } from "@/lib/server/apiAuthorization";
 
-// Get a specific user, finding the user by their userID
-export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
+    const admin = requireAdmin(await getRequestActor());
+    if (!admin.ok) return admin.response;
+
     const { id } = await params;
     if (!mongoose.Types.ObjectId.isValid(id)) {
       return NextResponse.json({ error: "Invalid user id" }, { status: 400 });
     }
-    await connectDB();
 
+    await connectDB();
     const user = await User.findById(id).lean();
     if (!user) {
       return NextResponse.json({ error: "User not found" }, { status: 404 });
     }
     return NextResponse.json(user, { status: 200 });
-  } catch (err: any) {
-    console.error("Caught an error", err);
-    return NextResponse.json({ error: err.message }, { status: 500 });
+  } catch (error) {
+    console.error("GET /api/users/:id error:", error);
+    return NextResponse.json({ error: "Failed to load user" }, { status: 500 });
   }
 }
 
-// Update a specific user, finding the user by their userID
-export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
+    const admin = requireAdmin(await getRequestActor());
+    if (!admin.ok) return admin.response;
+
     const { id } = await params;
-    const changes = await req.json();
     if (!mongoose.Types.ObjectId.isValid(id)) {
       return NextResponse.json({ error: "Invalid user id" }, { status: 400 });
     }
-    await connectDB();
 
-    const updatedUser = await User.findByIdAndUpdate(id, { $set: changes }, { new: true, runValidators: true }).lean();
+    const rawBody: unknown = await request.json();
+    if (!isPlainObject(rawBody)) {
+      return NextResponse.json({ error: "Request body must be an object" }, { status: 400 });
+    }
+
+    const name = typeof rawBody.name === "string" ? rawBody.name.trim() : "";
+    const email = typeof rawBody.email === "string" ? rawBody.email.trim() : "";
+    if (!name || !email) {
+      return NextResponse.json({ error: "Name and email are required" }, { status: 400 });
+    }
+
+    await connectDB();
+    const updatedUser = await User.findByIdAndUpdate(
+      id,
+      { $set: { name, email } },
+      { new: true, runValidators: true },
+    ).lean();
     if (!updatedUser) {
       return NextResponse.json({ error: "User not found" }, { status: 404 });
     }
 
     return NextResponse.json(updatedUser, { status: 200 });
-  } catch (err: any) {
-    console.error("Caught an error", err);
-    return NextResponse.json({ error: err.message }, { status: 400 });
+  } catch (error) {
+    console.error("PUT /api/users/:id error:", error);
+    return NextResponse.json({ error: "Failed to update user" }, { status: 500 });
   }
 }

--- a/src/app/api/users/me/photo/route.ts
+++ b/src/app/api/users/me/photo/route.ts
@@ -29,6 +29,6 @@ export async function PATCH(req: NextRequest) {
     return NextResponse.json({ ok: true, photo: updatedUser.photo }, { status: 200 });
   } catch (error: any) {
     console.error("PATCH /api/users/me/photo error:", error);
-    return NextResponse.json({ error: error?.message ?? "Failed to update photo" }, { status: 500 });
+    return NextResponse.json({ error: "Failed to update photo" }, { status: 500 });
   }
 }

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -41,6 +41,6 @@ export async function GET() {
     );
   } catch (error: any) {
     console.error("GET /api/users/me error:", error);
-    return NextResponse.json({ error: error?.message ?? "Failed to load user" }, { status: 500 });
+    return NextResponse.json({ error: "Failed to load user" }, { status: 500 });
   }
 }

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,60 +1,95 @@
 import connectDB from "@/database/db";
-import { NextResponse, NextRequest } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import User from "@/database/userSchema";
 import { DEFAULT_AVATAR_PHOTO, isValidAvatarPhoto } from "@/lib/avatarPhotos";
+import {
+  getRequestActor,
+  isPlainObject,
+  normalizeRole,
+  normalizeSelfAssignableRole,
+  requireAdmin,
+  requireSignedIn,
+} from "@/lib/server/apiAuthorization";
+import { clerkClient } from "@clerk/nextjs/server";
 
-function deriveUsername(body: Record<string, unknown>) {
-  const username = typeof body.username === "string" ? body.username.trim() : "";
-  if (username) return username;
-
-  const email = typeof body.email === "string" ? body.email.trim() : "";
-  if (email) return email.split("@")[0];
-
-  const name = typeof body.name === "string" ? body.name.trim() : "";
-  if (name) return name.toLowerCase().replace(/\s+/g, "");
-
-  const clerkId = typeof body.clerkId === "string" ? body.clerkId.trim() : "";
-  return clerkId;
+function deriveUsername(email: string, name: string, clerkUsername: string | null) {
+  return clerkUsername?.trim() || email.split("@")[0] || name.toLowerCase().replace(/\s+/g, "");
 }
 
-// CREATE a user with the parameters that are passed in, catching any server connection or bad requestst that may occur
-export async function POST(req: NextRequest) {
+export async function POST(request: NextRequest) {
   try {
-    await connectDB();
+    const signedIn = requireSignedIn(await getRequestActor());
+    if (!signedIn.ok) return signedIn.response;
 
-    const body = await req.json();
-    const requestedPhoto = typeof body.photo === "string" ? body.photo.trim() : DEFAULT_AVATAR_PHOTO;
-    const photo = isValidAvatarPhoto(requestedPhoto) ? requestedPhoto : DEFAULT_AVATAR_PHOTO;
-    const userData = {
-      ...body,
-      username: deriveUsername(body),
-      photo,
-    };
-
-    if (userData.clerkId) {
-      const existingUser = await User.findOne({ clerkId: userData.clerkId }).lean();
-      if (existingUser) {
-        return NextResponse.json(existingUser, { status: 200 });
-      }
+    const rawBody: unknown = await request.json().catch(() => null);
+    if (!isPlainObject(rawBody)) {
+      return NextResponse.json({ error: "Request body must be an object" }, { status: 400 });
     }
 
-    const user = await User.create(userData);
-    return NextResponse.json(user, { status: 201 });
-  } catch (err: any) {
-    console.error("Caught an error", err);
-    return NextResponse.json({ error: err.message }, { status: 400 });
+    const client = await clerkClient();
+    const clerkUser = await client.users.getUser(signedIn.value.userId);
+    const email = clerkUser.primaryEmailAddress?.emailAddress?.trim();
+    if (!email) {
+      return NextResponse.json({ error: "A verified Clerk email address is required" }, { status: 400 });
+    }
+
+    const name = clerkUser.fullName?.trim() || clerkUser.username?.trim() || "Player";
+    const requestedPhoto = typeof rawBody.photo === "string" ? rawBody.photo.trim() : DEFAULT_AVATAR_PHOTO;
+    const photo = isValidAvatarPhoto(requestedPhoto) ? requestedPhoto : DEFAULT_AVATAR_PHOTO;
+    const clerkRole = normalizeRole(clerkUser.publicMetadata?.role);
+    const requestedRole = normalizeSelfAssignableRole(rawBody.role);
+
+    await connectDB();
+    const existingUser = await User.findOne({ clerkId: signedIn.value.userId }).lean<{
+      role?: string;
+      photo?: string;
+    } | null>();
+    const existingRole = normalizeRole(existingUser?.role);
+    const role =
+      clerkRole === "admin"
+        ? "admin"
+        : existingRole && existingRole !== "admin"
+          ? existingRole
+          : clerkRole
+            ? clerkRole
+            : requestedRole;
+
+    const user = await User.findOneAndUpdate(
+      { clerkId: signedIn.value.userId },
+      {
+        $set: {
+          name,
+          username: deriveUsername(email, name, clerkUser.username),
+          email,
+          role,
+          photo: existingUser?.photo && isValidAvatarPhoto(existingUser.photo) ? existingUser.photo : photo,
+        },
+        $setOnInsert: { clerkId: signedIn.value.userId },
+      },
+      { new: true, upsert: true, setDefaultsOnInsert: true, runValidators: true },
+    ).lean();
+
+    await client.users.updateUserMetadata(signedIn.value.userId, {
+      publicMetadata: { ...clerkUser.publicMetadata, role },
+    });
+
+    return NextResponse.json(user, { status: existingUser ? 200 : 201 });
+  } catch (error) {
+    console.error("POST /api/users error:", error);
+    return NextResponse.json({ error: "Failed to create user" }, { status: 500 });
   }
 }
 
-// RETRIEVE all users from the database, catching any errors that may occur
 export async function GET() {
   try {
-    await connectDB();
+    const admin = requireAdmin(await getRequestActor());
+    if (!admin.ok) return admin.response;
 
-    const retrieved_users = await User.find({}).lean();
-    return NextResponse.json(retrieved_users, { status: 200 });
-  } catch (err: any) {
-    console.error("Caught an error", err);
-    return NextResponse.json({ error: err.message }, { status: 400 });
+    await connectDB();
+    const users = await User.find({}).lean();
+    return NextResponse.json(users, { status: 200 });
+  } catch (error) {
+    console.error("GET /api/users error:", error);
+    return NextResponse.json({ error: "Failed to load users" }, { status: 500 });
   }
 }

--- a/src/app/login/player/[[...rest]]/page.tsx
+++ b/src/app/login/player/[[...rest]]/page.tsx
@@ -93,16 +93,18 @@ export default function PlayerLoginPage() {
       const result = (await response.json()) as {
         error?: string;
         sessionId?: string;
+        expiresAt?: string;
         title?: string;
         participant?: { id: string; displayName: string };
       };
 
-      if (!response.ok || !result.sessionId) {
+      if (!response.ok || !result.sessionId || !result.expiresAt) {
         throw new Error(result.error || "Unable to join classroom session.");
       }
 
       writeClassroomSessionSnapshot({
         sessionId: result.sessionId,
+        expiresAt: result.expiresAt,
         title: result.title,
         displayName: result.participant?.displayName ?? studentName.trim(),
         code: normalizedCode,

--- a/src/components/GamePlayer.tsx
+++ b/src/components/GamePlayer.tsx
@@ -4,7 +4,7 @@ import UnityIFrame from "@/components/UnityIFrame";
 import { useAuth } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
 import { useRef, useState } from "react";
-import { readClassroomSessionSnapshot } from "@/lib/classroomSessionClient";
+import { clearClassroomSessionSnapshot, readClassroomSessionSnapshot } from "@/lib/classroomSessionClient";
 
 type Props = {
   game: string;
@@ -67,14 +67,14 @@ export default function GamePlayer({ game, saveId, sessionId, classroomId, userI
   const { userId: authUserId } = useAuth();
   const router = useRouter();
   const resolvedUserId = userId ?? authUserId ?? undefined;
-  const [clientSaveId, setClientSaveId] = useState<string | undefined>(saveId);
+  const [personalSaveId, setPersonalSaveId] = useState<string | undefined>(saveId);
+  const [classroomSaveId, setClassroomSaveId] = useState<string | undefined>();
+  const [activeClassroomSession, setActiveClassroomSession] = useState(() => readClassroomSessionSnapshot());
   const completionStarted = useRef(false);
 
-  const activeClassroomSession = readClassroomSessionSnapshot();
   const classroomSessionId = activeClassroomSession?.sessionId ?? classroomId;
   const classroomParticipantId = activeClassroomSession?.participantId;
-  const studentDisplayName = activeClassroomSession?.displayName;
-  const effectiveSaveId = saveId ?? clientSaveId;
+  const effectiveSaveId = classroomParticipantId ? classroomSaveId : (saveId ?? personalSaveId);
 
   const handleProgress = async (payload: unknown) => {
     const progressPayload = payload as ProgressPayload;
@@ -103,13 +103,25 @@ export default function GamePlayer({ game, saveId, sessionId, classroomId, userI
         const payload = {
           ...(completedLevels ? { completedLevels } : {}),
           ...(completedStageIds ? { completedStageIds } : {}),
-          lastUpdated: new Date().toISOString(),
-          classroomSessionId: classroomSessionId ?? null,
           classroomParticipantId: classroomParticipantId ?? null,
-          studentDisplayName: studentDisplayName ?? null,
         };
 
-        const response = effectiveSaveId
+        const createSave = () =>
+          fetch("/api/gameData", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              saveId: crypto.randomUUID(),
+              saveVersion: 1,
+              gameVersion: "1.0.0",
+              gameId: game,
+              ...payload,
+            }),
+          });
+
+        let response = effectiveSaveId
           ? await fetch(`/api/gameData/${effectiveSaveId}`, {
               method: "PATCH",
               headers: {
@@ -117,29 +129,28 @@ export default function GamePlayer({ game, saveId, sessionId, classroomId, userI
               },
               body: JSON.stringify(payload),
             })
-          : await fetch("/api/gameData", {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-              },
-              body: JSON.stringify({
-                saveId: crypto.randomUUID(),
-                saveVersion: 1,
-                gameVersion: "1.0.0",
-                gameId: game,
-                userId:
-                  resolvedUserId ?? (classroomParticipantId ? `participant:${classroomParticipantId}` : "guest-player"),
-                ...payload,
-              }),
-            });
+          : await createSave();
+
+        if (response.status === 404 && classroomParticipantId && effectiveSaveId) {
+          response = await createSave();
+        }
 
         if (!response.ok) {
+          if (classroomParticipantId && (response.status === 401 || response.status === 403)) {
+            clearClassroomSessionSnapshot();
+            setActiveClassroomSession(null);
+            setClassroomSaveId(undefined);
+          }
           console.error("Failed to save game data:", response.statusText);
         } else {
           const updatedData = await response.json();
-          if (!effectiveSaveId && typeof updatedData?.saveId === "string") {
+          if (typeof updatedData?.saveId === "string") {
             completionSaveId = updatedData.saveId;
-            setClientSaveId(updatedData.saveId);
+            if (classroomParticipantId) {
+              setClassroomSaveId(updatedData.saveId);
+            } else {
+              setPersonalSaveId(updatedData.saveId);
+            }
           }
           console.log("Game data saved successfully:", updatedData);
         }
@@ -158,10 +169,9 @@ export default function GamePlayer({ game, saveId, sessionId, classroomId, userI
           },
           body: JSON.stringify({
             eventId,
-            anonUserId: eventUserId,
             sessionId: resolvedSessionId,
             event: "level_completed",
-            ts: new Date().toISOString(),
+            classroomParticipantId: classroomParticipantId ?? null,
             props: {
               gameId: game,
               ...(levelCompleted !== undefined ? { levelCompleted } : {}),

--- a/src/components/QuizExperience.tsx
+++ b/src/components/QuizExperience.tsx
@@ -6,7 +6,7 @@ import QuizIntroView from "@/components/quiz/QuizIntroView";
 import QuizQuestionView from "@/components/quiz/QuizQuestionView";
 import QuizResultsView from "@/components/quiz/QuizResultsView";
 import { QuizQuestion } from "@/components/quiz/types";
-import { readClassroomSessionSnapshot } from "@/lib/classroomSessionClient";
+import { clearClassroomSessionSnapshot, readClassroomSessionSnapshot } from "@/lib/classroomSessionClient";
 
 export type { QuizOption, QuizQuestion } from "@/components/quiz/types";
 
@@ -132,13 +132,14 @@ export default function QuizExperience({
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             ...payload,
-            classroomSessionId: classroomSession?.sessionId,
             classroomParticipantId: classroomSession?.participantId,
-            studentDisplayName: classroomSession?.displayName,
           }),
         });
 
         if (!response.ok) {
+          if (classroomSession && (response.status === 401 || response.status === 403)) {
+            clearClassroomSessionSnapshot();
+          }
           throw new Error("Failed to save quiz results");
         }
 

--- a/src/database/classroomParticipantSchema.ts
+++ b/src/database/classroomParticipantSchema.ts
@@ -6,6 +6,7 @@ const ClassroomParticipantSchema = new Schema(
     accessCodeId: { type: Schema.Types.ObjectId, ref: "StudentAccessCode", required: true, index: true },
     participantKey: { type: String, required: true, trim: true, maxlength: 160 },
     clerkId: { type: String, default: null, trim: true },
+    authTokenHash: { type: String, default: null, select: false },
     displayName: { type: String, required: true, trim: true, maxlength: 80 },
     joinedAt: { type: Date, default: Date.now },
     lastSeenAt: { type: Date, default: Date.now },

--- a/src/database/eventSchema.ts
+++ b/src/database/eventSchema.ts
@@ -10,6 +10,9 @@ const EventSchema = new Schema({
     gameId: { type: String, default: null },
     durationMs: { type: Number, default: null },
     result: { type: String, default: null },
+    levelCompleted: { type: Number, default: null },
+    activityId: { type: String, default: null },
+    stageId: { type: String, default: null },
   },
 });
 

--- a/src/lib/classroomSessionClient.test.ts
+++ b/src/lib/classroomSessionClient.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { isClassroomSessionSnapshotActive } from "@/lib/classroomSessionClient";
+
+describe("classroom session snapshots", () => {
+  const now = Date.parse("2030-01-01T12:00:00.000Z");
+
+  it("accepts a classroom snapshot before its server expiry", () => {
+    expect(
+      isClassroomSessionSnapshotActive(
+        { sessionId: "session-1", participantId: "participant-1", expiresAt: "2030-01-01T13:00:00.000Z" },
+        now,
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects expired, legacy, and malformed snapshots", () => {
+    expect(
+      isClassroomSessionSnapshotActive({ sessionId: "session-1", expiresAt: "2030-01-01T11:00:00.000Z" }, now),
+    ).toBe(false);
+    expect(isClassroomSessionSnapshotActive({ sessionId: "session-1" }, now)).toBe(false);
+    expect(isClassroomSessionSnapshotActive("not-a-snapshot", now)).toBe(false);
+  });
+});

--- a/src/lib/classroomSessionClient.ts
+++ b/src/lib/classroomSessionClient.ts
@@ -2,11 +2,33 @@ export const CLASSROOM_SESSION_KEY = "kfi_current_classroom_session";
 
 export type ClassroomSessionSnapshot = {
   sessionId: string;
+  expiresAt: string;
   title?: string;
   displayName?: string;
   code?: string;
   participantId?: string;
 };
+
+export function clearClassroomSessionSnapshot() {
+  if (typeof window === "undefined") return;
+  window.localStorage.removeItem(CLASSROOM_SESSION_KEY);
+}
+
+export function isClassroomSessionSnapshotActive(
+  snapshot: unknown,
+  now = Date.now(),
+): snapshot is ClassroomSessionSnapshot {
+  if (!snapshot || typeof snapshot !== "object" || Array.isArray(snapshot)) return false;
+
+  const candidate = snapshot as Partial<ClassroomSessionSnapshot>;
+  const expiresAt = typeof candidate.expiresAt === "string" ? Date.parse(candidate.expiresAt) : NaN;
+  return (
+    typeof candidate.sessionId === "string" &&
+    candidate.sessionId.length > 0 &&
+    Number.isFinite(expiresAt) &&
+    expiresAt > now
+  );
+}
 
 export function readClassroomSessionSnapshot() {
   if (typeof window === "undefined") return null;
@@ -15,9 +37,13 @@ export function readClassroomSessionSnapshot() {
     const raw = window.localStorage.getItem(CLASSROOM_SESSION_KEY);
     if (!raw) return null;
 
-    const parsed = JSON.parse(raw) as ClassroomSessionSnapshot;
-    return parsed?.sessionId ? parsed : null;
+    const parsed: unknown = JSON.parse(raw);
+    if (isClassroomSessionSnapshotActive(parsed)) return parsed;
+
+    clearClassroomSessionSnapshot();
+    return null;
   } catch {
+    clearClassroomSessionSnapshot();
     return null;
   }
 }

--- a/src/lib/server/apiAuthorization.test.ts
+++ b/src/lib/server/apiAuthorization.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeRole,
+  normalizeSelfAssignableRole,
+  requireAdmin,
+  requireSignedIn,
+} from "@/lib/server/apiAuthorization";
+
+describe("API role policy", () => {
+  it("accepts only known application roles", () => {
+    expect(normalizeRole("player")).toBe("player");
+    expect(normalizeRole("admin")).toBe("admin");
+    expect(normalizeRole("owner")).toBeNull();
+    expect(normalizeRole(undefined)).toBeNull();
+  });
+
+  it("never allows self-registration to assign administrator access", () => {
+    expect(normalizeSelfAssignableRole("educator")).toBe("educator");
+    expect(normalizeSelfAssignableRole("parent")).toBe("parent");
+    expect(normalizeSelfAssignableRole("admin")).toBe("player");
+    expect(normalizeSelfAssignableRole("anything-else")).toBe("player");
+  });
+
+  it("requires a Clerk user for signed-in operations", async () => {
+    const result = requireSignedIn({ userId: null, role: null });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.response.status).toBe(401);
+  });
+
+  it("requires both a Clerk user and the administrator claim for admin operations", () => {
+    const player = requireAdmin({ userId: "user-1", role: "player" });
+    expect(player.ok).toBe(false);
+    if (!player.ok) expect(player.response.status).toBe(403);
+
+    const admin = requireAdmin({ userId: "admin-1", role: "admin" });
+    expect(admin).toMatchObject({ ok: true, value: { userId: "admin-1", role: "admin" } });
+  });
+});

--- a/src/lib/server/apiAuthorization.ts
+++ b/src/lib/server/apiAuthorization.ts
@@ -1,0 +1,68 @@
+import { auth } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+
+export const APP_ROLES = ["player", "parent", "educator", "admin"] as const;
+export const SELF_ASSIGNABLE_ROLES = ["player", "parent", "educator"] as const;
+
+export type AppRole = (typeof APP_ROLES)[number];
+
+export type RequestActor = {
+  userId: string | null;
+  role: AppRole | null;
+};
+
+export type AuthorizationResult<T> = { ok: true; value: T } | { ok: false; response: NextResponse };
+
+export function normalizeRole(value: unknown): AppRole | null {
+  return typeof value === "string" && APP_ROLES.includes(value as AppRole) ? (value as AppRole) : null;
+}
+
+export function normalizeSelfAssignableRole(value: unknown): Exclude<AppRole, "admin"> {
+  return typeof value === "string" && SELF_ASSIGNABLE_ROLES.includes(value as Exclude<AppRole, "admin">)
+    ? (value as Exclude<AppRole, "admin">)
+    : "player";
+}
+
+export async function getRequestActor(): Promise<RequestActor> {
+  const { userId, sessionClaims } = await auth();
+  return {
+    userId,
+    role: normalizeRole(sessionClaims?.role),
+  };
+}
+
+export function unauthorized(message = "Unauthorized") {
+  return NextResponse.json({ error: message }, { status: 401 });
+}
+
+export function forbidden(message = "Forbidden") {
+  return NextResponse.json({ error: message }, { status: 403 });
+}
+
+export function requireSignedIn(actor: RequestActor): AuthorizationResult<RequestActor & { userId: string }> {
+  if (!actor.userId) {
+    return { ok: false, response: unauthorized() };
+  }
+
+  return { ok: true, value: { ...actor, userId: actor.userId } };
+}
+
+export function requireAdmin(
+  actor: RequestActor,
+): AuthorizationResult<RequestActor & { userId: string; role: "admin" }> {
+  const signedIn = requireSignedIn(actor);
+  if (!signedIn.ok) return signedIn;
+
+  if (signedIn.value.role !== "admin") {
+    return { ok: false, response: forbidden("Administrator access required") };
+  }
+
+  return {
+    ok: true,
+    value: { ...signedIn.value, role: "admin" },
+  };
+}
+
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/lib/server/apiErrors.ts
+++ b/src/lib/server/apiErrors.ts
@@ -1,0 +1,6 @@
+export class ApiInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ApiInputError";
+  }
+}

--- a/src/lib/server/classroomAuthorization.test.ts
+++ b/src/lib/server/classroomAuthorization.test.ts
@@ -1,0 +1,146 @@
+import mongoose from "mongoose";
+import { NextRequest, NextResponse } from "next/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import ClassroomParticipant from "@/database/classroomParticipantSchema";
+import ClassroomSession from "@/database/classroomSessionSchema";
+import {
+  authorizeClassroomParticipant,
+  createClassroomCredential,
+  hashClassroomSecret,
+  parseClassroomCredential,
+  resolveDataPrincipal,
+  setClassroomCredentialCookie,
+} from "@/lib/server/classroomAuthorization";
+
+describe("classroom participant credentials", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("creates an opaque credential that resolves to the intended participant", () => {
+    const participantId = new mongoose.Types.ObjectId().toString();
+    const credential = createClassroomCredential(participantId);
+    const parsed = parseClassroomCredential(credential.cookieValue);
+
+    expect(parsed).toEqual({ participantId, tokenHash: credential.tokenHash });
+    expect(credential.cookieValue).not.toContain(credential.tokenHash);
+  });
+
+  it("rejects malformed or truncated credentials", () => {
+    const participantId = new mongoose.Types.ObjectId().toString();
+    expect(parseClassroomCredential(undefined)).toBeNull();
+    expect(parseClassroomCredential("not-a-credential")).toBeNull();
+    expect(parseClassroomCredential(`${participantId}.short`)).toBeNull();
+  });
+
+  it("changes the stored digest when a token is tampered with", () => {
+    expect(hashClassroomSecret("a-valid-secret-value")).not.toBe(hashClassroomSecret("a-tampered-secret-value"));
+  });
+
+  it("sets the credential as an HTTP-only same-origin cookie", () => {
+    const response = NextResponse.json({ ok: true });
+    setClassroomCredentialCookie(response, "participant.secret", new Date("2030-01-01T00:00:00.000Z"));
+
+    const header = response.headers.get("set-cookie");
+    expect(header).toContain("kfi_classroom_access=participant.secret");
+    expect(header).toContain("HttpOnly");
+    expect(header).toContain("SameSite=lax");
+    expect(header).toContain("Path=/");
+  });
+
+  it("authorizes a guest only when the cookie digest matches the claimed participant", async () => {
+    const participantId = new mongoose.Types.ObjectId().toString();
+    const sessionId = new mongoose.Types.ObjectId();
+    const credential = createClassroomCredential(participantId);
+    const lean = vi.fn().mockResolvedValue({
+      _id: new mongoose.Types.ObjectId(participantId),
+      sessionId,
+      clerkId: null,
+      displayName: "Student",
+    });
+    const findOne = vi.spyOn(ClassroomParticipant, "findOne").mockReturnValue({ lean } as never);
+    vi.spyOn(ClassroomSession, "exists").mockResolvedValue({ _id: sessionId } as never);
+
+    const request = new NextRequest("http://localhost/api/gameData", {
+      headers: { cookie: `kfi_classroom_access=${credential.cookieValue}` },
+    });
+    const result = await authorizeClassroomParticipant(request, { userId: null, role: null }, participantId);
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: { participantId, sessionId: String(sessionId), displayName: "Student", clerkId: null },
+    });
+    expect(findOne).toHaveBeenCalledWith({
+      _id: participantId,
+      authTokenHash: credential.tokenHash,
+      clerkId: null,
+    });
+  });
+
+  it("rejects a guest who claims a different participant", async () => {
+    const credentialParticipantId = new mongoose.Types.ObjectId().toString();
+    const claimedParticipantId = new mongoose.Types.ObjectId().toString();
+    const credential = createClassroomCredential(credentialParticipantId);
+    const request = new NextRequest("http://localhost/api/gameData", {
+      headers: { cookie: `kfi_classroom_access=${credential.cookieValue}` },
+    });
+
+    const result = await authorizeClassroomParticipant(request, { userId: null, role: null }, claimedParticipantId);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.response.status).toBe(403);
+  });
+
+  it("uses the classroom participant as owner even when the student is signed in", async () => {
+    const participantId = new mongoose.Types.ObjectId().toString();
+    const sessionId = new mongoose.Types.ObjectId();
+    const lean = vi.fn().mockResolvedValue({
+      _id: new mongoose.Types.ObjectId(participantId),
+      sessionId,
+      clerkId: "clerk-student",
+      displayName: "Signed-in Student",
+    });
+    vi.spyOn(ClassroomParticipant, "findOne").mockReturnValue({ lean } as never);
+    vi.spyOn(ClassroomSession, "exists").mockResolvedValue({ _id: sessionId } as never);
+
+    const request = new NextRequest("http://localhost/api/quiz");
+    const result = await resolveDataPrincipal(request, { userId: "clerk-student", role: "player" }, participantId);
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        ownerId: `participant:${participantId}`,
+        classroom: { participantId, sessionId: String(sessionId), clerkId: "clerk-student" },
+      },
+    });
+  });
+
+  it("uses the signed-in student's classroom credential when a read has no participant claim", async () => {
+    const participantId = new mongoose.Types.ObjectId().toString();
+    const sessionId = new mongoose.Types.ObjectId();
+    const credential = createClassroomCredential(participantId);
+    const lean = vi.fn().mockResolvedValue({
+      _id: new mongoose.Types.ObjectId(participantId),
+      sessionId,
+      clerkId: "clerk-student",
+      displayName: "Signed-in Student",
+    });
+    const findOne = vi.spyOn(ClassroomParticipant, "findOne").mockReturnValue({ lean } as never);
+    vi.spyOn(ClassroomSession, "exists").mockResolvedValue({ _id: sessionId } as never);
+
+    const request = new NextRequest("http://localhost/api/gameData/save-1", {
+      headers: { cookie: `kfi_classroom_access=${credential.cookieValue}` },
+    });
+    const result = await resolveDataPrincipal(request, { userId: "clerk-student", role: "player" });
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        ownerId: `participant:${participantId}`,
+        classroom: { participantId, sessionId: String(sessionId), clerkId: "clerk-student" },
+      },
+    });
+    expect(findOne).toHaveBeenCalledWith({
+      _id: participantId,
+      clerkId: "clerk-student",
+      authTokenHash: credential.tokenHash,
+    });
+  });
+});

--- a/src/lib/server/classroomAuthorization.ts
+++ b/src/lib/server/classroomAuthorization.ts
@@ -1,0 +1,188 @@
+import { createHash, randomBytes } from "node:crypto";
+import mongoose from "mongoose";
+import { NextRequest, NextResponse } from "next/server";
+import ClassroomParticipant from "@/database/classroomParticipantSchema";
+import ClassroomSession from "@/database/classroomSessionSchema";
+import Teacher from "@/database/teacherSchema";
+import User from "@/database/userSchema";
+import {
+  AuthorizationResult,
+  RequestActor,
+  forbidden,
+  requireSignedIn,
+  unauthorized,
+} from "@/lib/server/apiAuthorization";
+
+export const CLASSROOM_ACCESS_COOKIE = "kfi_classroom_access";
+
+type ClassroomParticipantRecord = {
+  _id: mongoose.Types.ObjectId;
+  sessionId: mongoose.Types.ObjectId;
+  clerkId?: string | null;
+  displayName: string;
+};
+
+export type AuthorizedClassroomParticipant = {
+  participantId: string;
+  sessionId: string;
+  displayName: string;
+  clerkId: string | null;
+};
+
+export type DataPrincipal = {
+  ownerId: string;
+  actor: RequestActor;
+  classroom: AuthorizedClassroomParticipant | null;
+};
+
+export function hashClassroomSecret(secret: string) {
+  return createHash("sha256").update(secret).digest("hex");
+}
+
+export function createClassroomCredential(participantId: string) {
+  const secret = randomBytes(32).toString("base64url");
+  return {
+    cookieValue: `${participantId}.${secret}`,
+    tokenHash: hashClassroomSecret(secret),
+  };
+}
+
+export function parseClassroomCredential(value: string | undefined) {
+  if (!value) return null;
+
+  const separatorIndex = value.indexOf(".");
+  if (separatorIndex <= 0 || separatorIndex === value.length - 1) return null;
+
+  const participantId = value.slice(0, separatorIndex);
+  const secret = value.slice(separatorIndex + 1);
+  if (!mongoose.Types.ObjectId.isValid(participantId) || secret.length < 32) return null;
+
+  return { participantId, tokenHash: hashClassroomSecret(secret) };
+}
+
+export function setClassroomCredentialCookie(response: NextResponse, cookieValue: string, expiresAt: Date) {
+  response.cookies.set({
+    name: CLASSROOM_ACCESS_COOKIE,
+    value: cookieValue,
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    expires: expiresAt,
+  });
+}
+
+async function findActiveParticipant(filter: Record<string, unknown>) {
+  const participant = await ClassroomParticipant.findOne(filter).lean<ClassroomParticipantRecord | null>();
+  if (!participant) return null;
+
+  const activeSession = await ClassroomSession.exists({
+    _id: participant.sessionId,
+    status: "active",
+    expiresAt: { $gt: new Date() },
+  });
+
+  return activeSession ? participant : null;
+}
+
+export async function authorizeClassroomParticipant(
+  request: NextRequest,
+  actor: RequestActor,
+  claimedParticipantId?: string,
+): Promise<AuthorizationResult<AuthorizedClassroomParticipant>> {
+  let participant: ClassroomParticipantRecord | null = null;
+  const credential = parseClassroomCredential(request.cookies.get(CLASSROOM_ACCESS_COOKIE)?.value);
+
+  if (actor.userId) {
+    const participantId = claimedParticipantId ?? credential?.participantId;
+    if (!participantId || !mongoose.Types.ObjectId.isValid(participantId)) {
+      return { ok: false, response: forbidden("Invalid classroom participant") };
+    }
+
+    participant = await findActiveParticipant({
+      _id: participantId,
+      clerkId: actor.userId,
+      ...(claimedParticipantId ? {} : { authTokenHash: credential?.tokenHash }),
+    });
+    if (!participant) {
+      return { ok: false, response: forbidden("Invalid classroom participant") };
+    }
+  } else {
+    if (!credential) {
+      return { ok: false, response: unauthorized("A valid classroom session is required") };
+    }
+    if (claimedParticipantId && claimedParticipantId !== credential.participantId) {
+      return { ok: false, response: forbidden("Invalid classroom participant") };
+    }
+
+    participant = await findActiveParticipant({
+      _id: credential.participantId,
+      authTokenHash: credential.tokenHash,
+      clerkId: null,
+    });
+    if (!participant) {
+      return { ok: false, response: unauthorized("A valid classroom session is required") };
+    }
+  }
+
+  return {
+    ok: true,
+    value: {
+      participantId: String(participant._id),
+      sessionId: String(participant.sessionId),
+      displayName: participant.displayName,
+      clerkId: participant.clerkId ?? null,
+    },
+  };
+}
+
+export async function resolveDataPrincipal(
+  request: NextRequest,
+  actor: RequestActor,
+  claimedParticipantId?: string,
+): Promise<AuthorizationResult<DataPrincipal>> {
+  const hasClassroomCredential = Boolean(parseClassroomCredential(request.cookies.get(CLASSROOM_ACCESS_COOKIE)?.value));
+
+  if (claimedParticipantId || !actor.userId || hasClassroomCredential) {
+    const classroomResult = await authorizeClassroomParticipant(request, actor, claimedParticipantId);
+    if (!classroomResult.ok) {
+      if (claimedParticipantId || !actor.userId) return classroomResult;
+    } else {
+      return {
+        ok: true,
+        value: {
+          ownerId: `participant:${classroomResult.value.participantId}`,
+          actor,
+          classroom: classroomResult.value,
+        },
+      };
+    }
+  }
+
+  return {
+    ok: true,
+    value: {
+      ownerId: actor.userId,
+      actor,
+      classroom: null,
+    },
+  };
+}
+
+export async function canEducatorReadClassroom(actor: RequestActor, classroomSessionId: string | null | undefined) {
+  if (!actor.userId || !classroomSessionId || !mongoose.Types.ObjectId.isValid(classroomSessionId)) return false;
+  if (actor.role === "admin") return true;
+
+  const signedIn = requireSignedIn(actor);
+  if (!signedIn.ok) return false;
+
+  const dbUser = await User.exists({ clerkId: signedIn.value.userId, role: "educator" });
+  if (!dbUser) return false;
+
+  const teacher = await Teacher.findOne({ clerkId: signedIn.value.userId }).lean<{
+    _id: mongoose.Types.ObjectId;
+  } | null>();
+  if (!teacher) return false;
+
+  return Boolean(await ClassroomSession.exists({ _id: classroomSessionId, teacherId: teacher._id }));
+}

--- a/src/lib/server/gameDataValidation.test.ts
+++ b/src/lib/server/gameDataValidation.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { parseGameDataProgress, parseNewGameData } from "@/lib/server/gameDataValidation";
+
+describe("game data input allowlists", () => {
+  it("returns only supported creation fields and removes duplicate progress", () => {
+    const parsed = parseNewGameData({
+      saveId: "save-1",
+      saveVersion: 1,
+      gameVersion: "1.0.0",
+      gameId: "PenguinRun",
+      completedLevels: [1, 1, 2],
+      userId: "forged-user",
+      classroomSessionId: "forged-session",
+      studentDisplayName: "Forged Name",
+      role: "admin",
+    });
+
+    expect(parsed).toEqual({
+      saveId: "save-1",
+      saveVersion: 1,
+      gameVersion: "1.0.0",
+      gameId: "PenguinRun",
+      completedLevels: [1, 2],
+      completedStageIds: [],
+    });
+    expect(parsed).not.toHaveProperty("userId");
+  });
+
+  it("accepts only completion arrays during progress updates", () => {
+    expect(parseGameDataProgress({ completedStageIds: ["pipes", "pipes", "sorting"], userId: "forged" })).toEqual({
+      completedLevels: undefined,
+      completedStageIds: ["pipes", "sorting"],
+    });
+    expect(() => parseGameDataProgress({ userId: "forged" })).toThrow("At least one completion field is required");
+  });
+
+  it("rejects unknown games and malformed progress", () => {
+    expect(() =>
+      parseNewGameData({
+        saveId: "save-1",
+        saveVersion: 1,
+        gameVersion: "1.0.0",
+        gameId: "NotARealGame",
+      }),
+    ).toThrow("gameId must be one of");
+    expect(() => parseGameDataProgress({ completedLevels: [1, "2"] })).toThrow(
+      "completedLevels must be an array of integers",
+    );
+  });
+});

--- a/src/lib/server/gameDataValidation.ts
+++ b/src/lib/server/gameDataValidation.ts
@@ -1,0 +1,64 @@
+import { ApiInputError } from "@/lib/server/apiErrors";
+
+export const GAME_IDS = ["PenguinRun", "StatesOfMatter", "penguinRunGame", "statesOfMatterGame"] as const;
+
+function requireString(value: unknown, field: string, maxLength = 160) {
+  if (typeof value !== "string" || value.trim().length === 0 || value.trim().length > maxLength) {
+    throw new ApiInputError(`${field} must be a non-empty string no longer than ${maxLength} characters`);
+  }
+  return value.trim();
+}
+
+export function parseIntegerArray(value: unknown, field: string): number[] {
+  if (!Array.isArray(value) || !value.every((item) => typeof item === "number" && Number.isInteger(item))) {
+    throw new ApiInputError(`${field} must be an array of integers`);
+  }
+  return Array.from(new Set(value));
+}
+
+export function parseStringArray(value: unknown, field: string): string[] {
+  if (
+    !Array.isArray(value) ||
+    !value.every((item) => typeof item === "string" && item.trim().length > 0 && item.trim().length <= 160)
+  ) {
+    throw new ApiInputError(`${field} must be an array of non-empty strings`);
+  }
+  return Array.from(new Set(value.map((item) => item.trim())));
+}
+
+export function parseNewGameData(body: Record<string, unknown>) {
+  const saveVersion = body.saveVersion;
+  if (typeof saveVersion !== "number" || !Number.isInteger(saveVersion) || saveVersion < 1) {
+    throw new ApiInputError("saveVersion must be a positive integer");
+  }
+
+  const gameId = requireString(body.gameId, "gameId", 80);
+  if (!GAME_IDS.includes(gameId as (typeof GAME_IDS)[number])) {
+    throw new ApiInputError(`gameId must be one of: ${GAME_IDS.join(", ")}`);
+  }
+
+  return {
+    saveId: requireString(body.saveId, "saveId", 160),
+    saveVersion,
+    gameVersion: requireString(body.gameVersion, "gameVersion", 80),
+    gameId,
+    completedLevels:
+      body.completedLevels === undefined ? [] : parseIntegerArray(body.completedLevels, "completedLevels"),
+    completedStageIds:
+      body.completedStageIds === undefined ? [] : parseStringArray(body.completedStageIds, "completedStageIds"),
+  };
+}
+
+export function parseGameDataProgress(body: Record<string, unknown>) {
+  const hasCompletedLevels = Object.prototype.hasOwnProperty.call(body, "completedLevels");
+  const hasCompletedStageIds = Object.prototype.hasOwnProperty.call(body, "completedStageIds");
+
+  if (!hasCompletedLevels && !hasCompletedStageIds) {
+    throw new ApiInputError("At least one completion field is required");
+  }
+
+  return {
+    completedLevels: hasCompletedLevels ? parseIntegerArray(body.completedLevels, "completedLevels") : undefined,
+    completedStageIds: hasCompletedStageIds ? parseStringArray(body.completedStageIds, "completedStageIds") : undefined,
+  };
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,7 +1,14 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
-const isPublicRoute = createRouteMatcher(["/login(.*)", "/api/quiz(.*)", "/sign-up(.*)"]);
+const isPublicPage = createRouteMatcher(["/login(.*)", "/sign-up(.*)"]);
+const isGuestCapableApi = createRouteMatcher([
+  "/api/classroom-sessions/join",
+  "/api/events(.*)",
+  "/api/gameData(.*)",
+  "/api/quiz(.*)",
+]);
+const isApiRoute = createRouteMatcher(["/api(.*)"]);
 const isAdminRoute = createRouteMatcher(["/adminDashboard(.*)"]);
 
 // !IMPORTANT, add this to your env:
@@ -12,8 +19,13 @@ const isAdminRoute = createRouteMatcher(["/adminDashboard(.*)"]);
 // https://clerk.com/docs/guides/sessions/customize-session-tokens
 
 export default clerkMiddleware(async (auth, req) => {
-  if (isPublicRoute(req)) return NextResponse.next();
-  const { sessionClaims } = await auth();
+  if (isPublicPage(req) || isGuestCapableApi(req)) return NextResponse.next();
+
+  const { userId, sessionClaims } = await auth();
+  if (isApiRoute(req) && !userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   const role = sessionClaims?.role;
 
   // Protect admin routes (can pass an error instead)

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,14 @@
+import { fileURLToPath, URL } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+    },
+  },
+  test: {
+    environment: "node",
+    clearMocks: true,
+  },
+});


### PR DESCRIPTION
## Developer: Matthew Lin

Closes #46

### Pull Request Summary

Enforces server-derived authentication, role checks, and record ownership across the API surface while preserving credentialed classroom guest play.

### Modifications

- Adds shared Clerk and classroom authorization helpers with opaque, HTTP-only classroom credentials.
- Restricts aggregate APIs to administrators and owner-scopes user, session, game save, quiz, and event operations.
- Prevents client-assigned identities, administrator roles, and unsupported save fields.
- Separates signed-in classroom data by participant and expires stale classroom browser state.
- Adds authorization policy documentation and 22 unit tests covering role, ownership, credential, and validation boundaries.

### Testing Considerations

- `npm test` (22 passing)
- `npm run lint`
- Production `npm run build` with placeholder Clerk/Mongo configuration
- Three independent local review passes; final pass reported no actionable findings
- Manual verification requested for signed-in player, classroom guest, educator, and admin workflows before merge

### Pull Request Checklist

- [x] Code is neat, readable, and works
- [x] Comments are appropriate
- [x] The commit message follows the conventional commit guidelines
- [x] The developer name is specified
- [x] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

Not applicable; this change is API authorization and persistence behavior.