### PR TITLE
Fix classroom post-quiz progress

### DIFF
--- a/src/app/penguinRunQuiz/page.tsx
+++ b/src/app/penguinRunQuiz/page.tsx
@@ -1,8 +1,9 @@
 import QuizExperience from "@/components/QuizExperience";
 import { getQuizQuestions } from "@/data/quizData";
-import connectDB from "@/database/db";
-import Quiz from "@/database/quizSchema";
-import { auth } from "@clerk/nextjs/server";
+import { cookies } from "next/headers";
+import { getRequestActor } from "@/lib/server/apiAuthorization";
+import { CLASSROOM_ACCESS_COOKIE } from "@/lib/server/classroomAuthorization";
+import { getPreviousQuizScore } from "@/lib/server/quizProgress";
 
 type QuizPageProps = {
   searchParams?: Promise<{
@@ -19,13 +20,12 @@ export default async function PeguinRunQuizPage({ searchParams }: QuizPageProps)
   let previousCorrectCount = -1;
 
   if (quizPhase === "after") {
-    const { userId } = await auth();
-
-    if (userId) {
-      await connectDB();
-      const quiz = await Quiz.findOne({ clerkId: userId }).lean<{ penguinRunScoreBefore?: number } | null>();
-      previousCorrectCount = typeof quiz?.penguinRunScoreBefore === "number" ? quiz.penguinRunScoreBefore : -1;
-    }
+    const cookieStore = await cookies();
+    previousCorrectCount = await getPreviousQuizScore(
+      "penguinRunQuiz",
+      await getRequestActor(),
+      cookieStore.get(CLASSROOM_ACCESS_COOKIE)?.value,
+    );
   }
 
   const gameHref =

--- a/src/app/threeStatesOfMatterQuiz/page.tsx
+++ b/src/app/threeStatesOfMatterQuiz/page.tsx
@@ -1,8 +1,9 @@
 import QuizExperience from "@/components/QuizExperience";
 import { getQuizQuestions } from "@/data/quizData";
-import connectDB from "@/database/db";
-import Quiz from "@/database/quizSchema";
-import { auth } from "@clerk/nextjs/server";
+import { cookies } from "next/headers";
+import { getRequestActor } from "@/lib/server/apiAuthorization";
+import { CLASSROOM_ACCESS_COOKIE } from "@/lib/server/classroomAuthorization";
+import { getPreviousQuizScore } from "@/lib/server/quizProgress";
 
 type QuizPageProps = {
   searchParams?: Promise<{
@@ -19,13 +20,12 @@ export default async function ThreeStatesOfMatterQuizPage({ searchParams }: Quiz
   let previousCorrectCount = -1;
 
   if (quizPhase === "after") {
-    const { userId } = await auth();
-
-    if (userId) {
-      await connectDB();
-      const quiz = await Quiz.findOne({ clerkId: userId }).lean<{ statesOfMatterScoreBefore?: number } | null>();
-      previousCorrectCount = typeof quiz?.statesOfMatterScoreBefore === "number" ? quiz.statesOfMatterScoreBefore : -1;
-    }
+    const cookieStore = await cookies();
+    previousCorrectCount = await getPreviousQuizScore(
+      "statesOfMatterQuiz",
+      await getRequestActor(),
+      cookieStore.get(CLASSROOM_ACCESS_COOKIE)?.value,
+    );
   }
 
   const gameHref =

--- a/src/lib/server/classroomAuthorization.test.ts
+++ b/src/lib/server/classroomAuthorization.test.ts
@@ -9,6 +9,7 @@ import {
   hashClassroomSecret,
   parseClassroomCredential,
   resolveDataPrincipal,
+  resolveDataPrincipalFromCredential,
   setClassroomCredentialCookie,
 } from "@/lib/server/classroomAuthorization";
 
@@ -142,5 +143,41 @@ describe("classroom participant credentials", () => {
       clerkId: "clerk-student",
       authTokenHash: credential.tokenHash,
     });
+  });
+
+  it("resolves a server-rendered read from the classroom cookie without a client claim", async () => {
+    const participantId = new mongoose.Types.ObjectId().toString();
+    const sessionId = new mongoose.Types.ObjectId();
+    const credential = createClassroomCredential(participantId);
+    const lean = vi.fn().mockResolvedValue({
+      _id: new mongoose.Types.ObjectId(participantId),
+      sessionId,
+      clerkId: null,
+      displayName: "Guest Student",
+    });
+    const findOne = vi.spyOn(ClassroomParticipant, "findOne").mockReturnValue({ lean } as never);
+    vi.spyOn(ClassroomSession, "exists").mockResolvedValue({ _id: sessionId } as never);
+
+    const result = await resolveDataPrincipalFromCredential(credential.cookieValue, { userId: null, role: null });
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        ownerId: `participant:${participantId}`,
+        classroom: { participantId, sessionId: String(sessionId) },
+      },
+    });
+    expect(findOne).toHaveBeenCalledWith({
+      _id: participantId,
+      authTokenHash: credential.tokenHash,
+      clerkId: null,
+    });
+  });
+
+  it("does not resolve an expired or invalid server classroom credential", async () => {
+    const result = await resolveDataPrincipalFromCredential("invalid", { userId: null, role: null });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.response.status).toBe(401);
   });
 });

--- a/src/lib/server/classroomAuthorization.ts
+++ b/src/lib/server/classroomAuthorization.ts
@@ -35,6 +35,11 @@ export type DataPrincipal = {
   classroom: AuthorizedClassroomParticipant | null;
 };
 
+type ParsedClassroomCredential = {
+  participantId: string;
+  tokenHash: string;
+};
+
 export function hashClassroomSecret(secret: string) {
   return createHash("sha256").update(secret).digest("hex");
 }
@@ -90,8 +95,19 @@ export async function authorizeClassroomParticipant(
   actor: RequestActor,
   claimedParticipantId?: string,
 ): Promise<AuthorizationResult<AuthorizedClassroomParticipant>> {
+  return authorizeClassroomParticipantWithCredential(
+    parseClassroomCredential(request.cookies.get(CLASSROOM_ACCESS_COOKIE)?.value),
+    actor,
+    claimedParticipantId,
+  );
+}
+
+async function authorizeClassroomParticipantWithCredential(
+  credential: ParsedClassroomCredential | null,
+  actor: RequestActor,
+  claimedParticipantId?: string,
+): Promise<AuthorizationResult<AuthorizedClassroomParticipant>> {
   let participant: ClassroomParticipantRecord | null = null;
-  const credential = parseClassroomCredential(request.cookies.get(CLASSROOM_ACCESS_COOKIE)?.value);
 
   if (actor.userId) {
     const participantId = claimedParticipantId ?? credential?.participantId;
@@ -136,15 +152,16 @@ export async function authorizeClassroomParticipant(
   };
 }
 
-export async function resolveDataPrincipal(
-  request: NextRequest,
+export async function resolveDataPrincipalFromCredential(
+  credentialValue: string | undefined,
   actor: RequestActor,
   claimedParticipantId?: string,
 ): Promise<AuthorizationResult<DataPrincipal>> {
-  const hasClassroomCredential = Boolean(parseClassroomCredential(request.cookies.get(CLASSROOM_ACCESS_COOKIE)?.value));
+  const credential = parseClassroomCredential(credentialValue);
+  const hasClassroomCredential = Boolean(credential);
 
   if (claimedParticipantId || !actor.userId || hasClassroomCredential) {
-    const classroomResult = await authorizeClassroomParticipant(request, actor, claimedParticipantId);
+    const classroomResult = await authorizeClassroomParticipantWithCredential(credential, actor, claimedParticipantId);
     if (!classroomResult.ok) {
       if (claimedParticipantId || !actor.userId) return classroomResult;
     } else {
@@ -167,6 +184,18 @@ export async function resolveDataPrincipal(
       classroom: null,
     },
   };
+}
+
+export async function resolveDataPrincipal(
+  request: NextRequest,
+  actor: RequestActor,
+  claimedParticipantId?: string,
+): Promise<AuthorizationResult<DataPrincipal>> {
+  return resolveDataPrincipalFromCredential(
+    request.cookies.get(CLASSROOM_ACCESS_COOKIE)?.value,
+    actor,
+    claimedParticipantId,
+  );
 }
 
 export async function canEducatorReadClassroom(actor: RequestActor, classroomSessionId: string | null | undefined) {

--- a/src/lib/server/classroomAuthorization.ts
+++ b/src/lib/server/classroomAuthorization.ts
@@ -215,36 +215,3 @@ export async function canEducatorReadClassroom(actor: RequestActor, classroomSes
 
   return Boolean(await ClassroomSession.exists({ _id: classroomSessionId, teacherId: teacher._id }));
 }
-
-/**
- * Finds the classroom participant a signed-in student is currently active in, without requiring the
- * classroom cookie. Scoped to the caller's own `clerkId`, so it cannot widen access — it only
- * recovers a read principal when the cookie has lapsed but the participant row is still live.
- * Read-only callers should prefer the cookie-backed principal and fall back to this.
- */
-export async function findActiveClassroomParticipantForUser(
-  userId: string,
-): Promise<AuthorizedClassroomParticipant | null> {
-  const participants = await ClassroomParticipant.find({ clerkId: userId })
-    .sort({ lastSeenAt: -1 })
-    .lean<ClassroomParticipantRecord[]>();
-
-  for (const participant of participants) {
-    const isActive = await ClassroomSession.exists({
-      _id: participant.sessionId,
-      status: "active",
-      expiresAt: { $gt: new Date() },
-    });
-
-    if (isActive) {
-      return {
-        participantId: String(participant._id),
-        sessionId: String(participant.sessionId),
-        displayName: participant.displayName,
-        clerkId: participant.clerkId ?? null,
-      };
-    }
-  }
-
-  return null;
-}

--- a/src/lib/server/classroomAuthorization.ts
+++ b/src/lib/server/classroomAuthorization.ts
@@ -215,3 +215,36 @@ export async function canEducatorReadClassroom(actor: RequestActor, classroomSes
 
   return Boolean(await ClassroomSession.exists({ _id: classroomSessionId, teacherId: teacher._id }));
 }
+
+/**
+ * Finds the classroom participant a signed-in student is currently active in, without requiring the
+ * classroom cookie. Scoped to the caller's own `clerkId`, so it cannot widen access — it only
+ * recovers a read principal when the cookie has lapsed but the participant row is still live.
+ * Read-only callers should prefer the cookie-backed principal and fall back to this.
+ */
+export async function findActiveClassroomParticipantForUser(
+  userId: string,
+): Promise<AuthorizedClassroomParticipant | null> {
+  const participants = await ClassroomParticipant.find({ clerkId: userId })
+    .sort({ lastSeenAt: -1 })
+    .lean<ClassroomParticipantRecord[]>();
+
+  for (const participant of participants) {
+    const isActive = await ClassroomSession.exists({
+      _id: participant.sessionId,
+      status: "active",
+      expiresAt: { $gt: new Date() },
+    });
+
+    if (isActive) {
+      return {
+        participantId: String(participant._id),
+        sessionId: String(participant.sessionId),
+        displayName: participant.displayName,
+        clerkId: participant.clerkId ?? null,
+      };
+    }
+  }
+
+  return null;
+}

--- a/src/lib/server/quizProgress.test.ts
+++ b/src/lib/server/quizProgress.test.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RequestActor } from "@/lib/server/apiAuthorization";
+
+const mocks = vi.hoisted(() => ({
+  connectDB: vi.fn(),
+  findOne: vi.fn(),
+  resolveDataPrincipalFromCredential: vi.fn(),
+}));
+
+vi.mock("@/database/db", () => ({ default: mocks.connectDB }));
+vi.mock("@/database/quizSchema", () => ({ default: { findOne: mocks.findOne } }));
+vi.mock("@/lib/server/classroomAuthorization", () => ({
+  resolveDataPrincipalFromCredential: mocks.resolveDataPrincipalFromCredential,
+}));
+
+import { getPreviousQuizScore } from "@/lib/server/quizProgress";
+
+const actor: RequestActor = { userId: "clerk-student", role: "player" };
+
+describe("getPreviousQuizScore", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.resolveDataPrincipalFromCredential.mockResolvedValue({
+      ok: true,
+      value: { ownerId: "clerk-student", actor, classroom: null },
+    });
+    mocks.findOne.mockReturnValue({
+      lean: vi.fn().mockResolvedValue({ penguinRunScoreBefore: 1, statesOfMatterScoreBefore: 2 }),
+    });
+  });
+
+  it("loads the personal player's previous score", async () => {
+    await expect(getPreviousQuizScore("penguinRunQuiz", actor)).resolves.toBe(1);
+
+    expect(mocks.resolveDataPrincipalFromCredential).toHaveBeenCalledWith(undefined, actor);
+    expect(mocks.findOne).toHaveBeenCalledWith({ clerkId: "clerk-student" });
+  });
+
+  it("loads a classroom participant's previous score by the authorized participant owner", async () => {
+    const classroomActor: RequestActor = { userId: null, role: null };
+    mocks.resolveDataPrincipalFromCredential.mockResolvedValue({
+      ok: true,
+      value: {
+        ownerId: "participant:participant-1",
+        actor: classroomActor,
+        classroom: {
+          participantId: "participant-1",
+          sessionId: "session-1",
+          displayName: "Student",
+          clerkId: null,
+        },
+      },
+    });
+
+    await expect(getPreviousQuizScore("statesOfMatterQuiz", classroomActor, "opaque-cookie")).resolves.toBe(2);
+
+    expect(mocks.resolveDataPrincipalFromCredential).toHaveBeenCalledWith("opaque-cookie", classroomActor);
+    expect(mocks.findOne).toHaveBeenCalledWith({ clerkId: "participant:participant-1" });
+  });
+
+  it("returns no score without querying quiz data when the credential is unauthorized", async () => {
+    mocks.resolveDataPrincipalFromCredential.mockResolvedValue({
+      ok: false,
+      response: NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    });
+
+    await expect(getPreviousQuizScore("penguinRunQuiz", { userId: null, role: null }, "expired-cookie")).resolves.toBe(
+      -1,
+    );
+    expect(mocks.connectDB).not.toHaveBeenCalled();
+    expect(mocks.findOne).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/server/quizProgress.test.ts
+++ b/src/lib/server/quizProgress.test.ts
@@ -6,17 +6,26 @@ const mocks = vi.hoisted(() => ({
   connectDB: vi.fn(),
   findOne: vi.fn(),
   resolveDataPrincipalFromCredential: vi.fn(),
+  findActiveClassroomParticipantForUser: vi.fn(),
 }));
 
 vi.mock("@/database/db", () => ({ default: mocks.connectDB }));
 vi.mock("@/database/quizSchema", () => ({ default: { findOne: mocks.findOne } }));
 vi.mock("@/lib/server/classroomAuthorization", () => ({
   resolveDataPrincipalFromCredential: mocks.resolveDataPrincipalFromCredential,
+  findActiveClassroomParticipantForUser: mocks.findActiveClassroomParticipantForUser,
 }));
 
 import { getPreviousQuizScore } from "@/lib/server/quizProgress";
 
 const actor: RequestActor = { userId: "clerk-student", role: "player" };
+
+/** Answers `Quiz.findOne` per owner key, so a test can give the personal and participant records different scores. */
+function stubQuizzesByOwner(byOwner: Record<string, unknown>) {
+  mocks.findOne.mockImplementation((filter: { clerkId: string }) => ({
+    lean: vi.fn().mockResolvedValue(byOwner[filter.clerkId] ?? null),
+  }));
+}
 
 describe("getPreviousQuizScore", () => {
   beforeEach(() => {
@@ -25,9 +34,8 @@ describe("getPreviousQuizScore", () => {
       ok: true,
       value: { ownerId: "clerk-student", actor, classroom: null },
     });
-    mocks.findOne.mockReturnValue({
-      lean: vi.fn().mockResolvedValue({ penguinRunScoreBefore: 1, statesOfMatterScoreBefore: 2 }),
-    });
+    mocks.findActiveClassroomParticipantForUser.mockResolvedValue(null);
+    stubQuizzesByOwner({ "clerk-student": { penguinRunScoreBefore: 1, statesOfMatterScoreBefore: 2 } });
   });
 
   it("loads the personal player's previous score", async () => {
@@ -35,6 +43,17 @@ describe("getPreviousQuizScore", () => {
 
     expect(mocks.resolveDataPrincipalFromCredential).toHaveBeenCalledWith(undefined, actor);
     expect(mocks.findOne).toHaveBeenCalledWith({ clerkId: "clerk-student" });
+  });
+
+  it("opens the database connection before resolving the principal", async () => {
+    // The resolver queries participants and sessions itself, so connecting afterwards would leave
+    // that query buffering on a cold instance until mongoose times out.
+    await getPreviousQuizScore("penguinRunQuiz", actor);
+
+    expect(mocks.connectDB).toHaveBeenCalled();
+    expect(mocks.connectDB.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.resolveDataPrincipalFromCredential.mock.invocationCallOrder[0],
+    );
   });
 
   it("loads a classroom participant's previous score by the authorized participant owner", async () => {
@@ -52,6 +71,7 @@ describe("getPreviousQuizScore", () => {
         },
       },
     });
+    stubQuizzesByOwner({ "participant:participant-1": { statesOfMatterScoreBefore: 2 } });
 
     await expect(getPreviousQuizScore("statesOfMatterQuiz", classroomActor, "opaque-cookie")).resolves.toBe(2);
 
@@ -68,7 +88,58 @@ describe("getPreviousQuizScore", () => {
     await expect(getPreviousQuizScore("penguinRunQuiz", { userId: null, role: null }, "expired-cookie")).resolves.toBe(
       -1,
     );
-    expect(mocks.connectDB).not.toHaveBeenCalled();
     expect(mocks.findOne).not.toHaveBeenCalled();
+  });
+
+  it("recovers the classroom baseline when the cookie lapsed but the participant is still active", async () => {
+    stubQuizzesByOwner({
+      "clerk-student": { statesOfMatterScoreBefore: -1 },
+      "participant:participant-9": { statesOfMatterScoreBefore: 2 },
+    });
+    mocks.findActiveClassroomParticipantForUser.mockResolvedValue({
+      participantId: "participant-9",
+      sessionId: "session-1",
+      displayName: "Student",
+      clerkId: "clerk-student",
+    });
+
+    await expect(getPreviousQuizScore("statesOfMatterQuiz", actor)).resolves.toBe(2);
+    expect(mocks.findActiveClassroomParticipantForUser).toHaveBeenCalledWith("clerk-student");
+  });
+
+  it("never lets a classroom baseline override a real personal score", async () => {
+    stubQuizzesByOwner({
+      "clerk-student": { statesOfMatterScoreBefore: 3 },
+      "participant:participant-9": { statesOfMatterScoreBefore: 0 },
+    });
+    mocks.findActiveClassroomParticipantForUser.mockResolvedValue({
+      participantId: "participant-9",
+      sessionId: "session-1",
+      displayName: "Student",
+      clerkId: "clerk-student",
+    });
+
+    await expect(getPreviousQuizScore("statesOfMatterQuiz", actor)).resolves.toBe(3);
+    expect(mocks.findActiveClassroomParticipantForUser).not.toHaveBeenCalled();
+  });
+
+  it("does not look for a classroom fallback for an anonymous caller", async () => {
+    mocks.resolveDataPrincipalFromCredential.mockResolvedValue({
+      ok: true,
+      value: { ownerId: "participant:participant-1", actor: { userId: null, role: null }, classroom: null },
+    });
+    stubQuizzesByOwner({});
+
+    await expect(getPreviousQuizScore("penguinRunQuiz", { userId: null, role: null })).resolves.toBe(-1);
+    expect(mocks.findActiveClassroomParticipantForUser).not.toHaveBeenCalled();
+  });
+
+  it("degrades to no previous score instead of failing the page when the database errors", async () => {
+    mocks.resolveDataPrincipalFromCredential.mockRejectedValue(new Error("connection lost"));
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(getPreviousQuizScore("penguinRunQuiz", actor)).resolves.toBe(-1);
+
+    consoleError.mockRestore();
   });
 });

--- a/src/lib/server/quizProgress.test.ts
+++ b/src/lib/server/quizProgress.test.ts
@@ -6,14 +6,12 @@ const mocks = vi.hoisted(() => ({
   connectDB: vi.fn(),
   findOne: vi.fn(),
   resolveDataPrincipalFromCredential: vi.fn(),
-  findActiveClassroomParticipantForUser: vi.fn(),
 }));
 
 vi.mock("@/database/db", () => ({ default: mocks.connectDB }));
 vi.mock("@/database/quizSchema", () => ({ default: { findOne: mocks.findOne } }));
 vi.mock("@/lib/server/classroomAuthorization", () => ({
   resolveDataPrincipalFromCredential: mocks.resolveDataPrincipalFromCredential,
-  findActiveClassroomParticipantForUser: mocks.findActiveClassroomParticipantForUser,
 }));
 
 import { getPreviousQuizScore } from "@/lib/server/quizProgress";
@@ -34,7 +32,6 @@ describe("getPreviousQuizScore", () => {
       ok: true,
       value: { ownerId: "clerk-student", actor, classroom: null },
     });
-    mocks.findActiveClassroomParticipantForUser.mockResolvedValue(null);
     stubQuizzesByOwner({ "clerk-student": { penguinRunScoreBefore: 1, statesOfMatterScoreBefore: 2 } });
   });
 
@@ -91,51 +88,18 @@ describe("getPreviousQuizScore", () => {
     expect(mocks.findOne).not.toHaveBeenCalled();
   });
 
-  it("recovers the classroom baseline when the cookie lapsed but the participant is still active", async () => {
-    stubQuizzesByOwner({
-      "clerk-student": { statesOfMatterScoreBefore: -1 },
-      "participant:participant-9": { statesOfMatterScoreBefore: 2 },
-    });
-    mocks.findActiveClassroomParticipantForUser.mockResolvedValue({
-      participantId: "participant-9",
-      sessionId: "session-1",
-      displayName: "Student",
-      clerkId: "clerk-student",
-    });
-
-    await expect(getPreviousQuizScore("statesOfMatterQuiz", actor)).resolves.toBe(2);
-    expect(mocks.findActiveClassroomParticipantForUser).toHaveBeenCalledWith("clerk-student");
-  });
-
-  it("never lets a classroom baseline override a real personal score", async () => {
-    stubQuizzesByOwner({
-      "clerk-student": { statesOfMatterScoreBefore: 3 },
-      "participant:participant-9": { statesOfMatterScoreBefore: 0 },
-    });
-    mocks.findActiveClassroomParticipantForUser.mockResolvedValue({
-      participantId: "participant-9",
-      sessionId: "session-1",
-      displayName: "Student",
-      clerkId: "clerk-student",
-    });
-
-    await expect(getPreviousQuizScore("statesOfMatterQuiz", actor)).resolves.toBe(3);
-    expect(mocks.findActiveClassroomParticipantForUser).not.toHaveBeenCalled();
-  });
-
-  it("does not look for a classroom fallback for an anonymous caller", async () => {
-    mocks.resolveDataPrincipalFromCredential.mockResolvedValue({
-      ok: true,
-      value: { ownerId: "participant:participant-1", actor: { userId: null, role: null }, classroom: null },
-    });
-    stubQuizzesByOwner({});
-
-    await expect(getPreviousQuizScore("penguinRunQuiz", { userId: null, role: null })).resolves.toBe(-1);
-    expect(mocks.findActiveClassroomParticipantForUser).not.toHaveBeenCalled();
-  });
-
-  it("degrades to no previous score instead of failing the page when the database errors", async () => {
+  it("degrades to no previous score instead of failing the page when the principal cannot be resolved", async () => {
     mocks.resolveDataPrincipalFromCredential.mockRejectedValue(new Error("connection lost"));
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(getPreviousQuizScore("penguinRunQuiz", actor)).resolves.toBe(-1);
+
+    consoleError.mockRestore();
+  });
+
+  it("degrades to no previous score when the quiz lookup itself fails", async () => {
+    // Covers the second await inside the try block, not just the first.
+    mocks.findOne.mockReturnValue({ lean: vi.fn().mockRejectedValue(new Error("read timeout")) });
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
 
     await expect(getPreviousQuizScore("penguinRunQuiz", actor)).resolves.toBe(-1);

--- a/src/lib/server/quizProgress.ts
+++ b/src/lib/server/quizProgress.ts
@@ -1,0 +1,29 @@
+import connectDB from "@/database/db";
+import Quiz from "@/database/quizSchema";
+import { RequestActor } from "@/lib/server/apiAuthorization";
+import { resolveDataPrincipalFromCredential } from "@/lib/server/classroomAuthorization";
+
+type QuizKey = "penguinRunQuiz" | "statesOfMatterQuiz";
+
+type QuizBeforeScores = {
+  penguinRunScoreBefore?: unknown;
+  statesOfMatterScoreBefore?: unknown;
+};
+
+function getBeforeScoreField(quizKey: QuizKey): keyof QuizBeforeScores {
+  return quizKey === "penguinRunQuiz" ? "penguinRunScoreBefore" : "statesOfMatterScoreBefore";
+}
+
+export async function getPreviousQuizScore(
+  quizKey: QuizKey,
+  actor: RequestActor,
+  classroomCredential?: string,
+): Promise<number> {
+  const principal = await resolveDataPrincipalFromCredential(classroomCredential, actor);
+  if (!principal.ok || !principal.value.ownerId) return -1;
+
+  await connectDB();
+  const quiz = await Quiz.findOne({ clerkId: principal.value.ownerId }).lean<QuizBeforeScores | null>();
+  const score = quiz?.[getBeforeScoreField(quizKey)];
+  return typeof score === "number" ? score : -1;
+}

--- a/src/lib/server/quizProgress.ts
+++ b/src/lib/server/quizProgress.ts
@@ -1,7 +1,10 @@
 import connectDB from "@/database/db";
 import Quiz from "@/database/quizSchema";
 import { RequestActor } from "@/lib/server/apiAuthorization";
-import { resolveDataPrincipalFromCredential } from "@/lib/server/classroomAuthorization";
+import {
+  findActiveClassroomParticipantForUser,
+  resolveDataPrincipalFromCredential,
+} from "@/lib/server/classroomAuthorization";
 
 type QuizKey = "penguinRunQuiz" | "statesOfMatterQuiz";
 
@@ -14,16 +17,40 @@ function getBeforeScoreField(quizKey: QuizKey): keyof QuizBeforeScores {
   return quizKey === "penguinRunQuiz" ? "penguinRunScoreBefore" : "statesOfMatterScoreBefore";
 }
 
+async function readBeforeScore(ownerId: string, quizKey: QuizKey) {
+  const quiz = await Quiz.findOne({ clerkId: ownerId }).lean<QuizBeforeScores | null>();
+  const score = quiz?.[getBeforeScoreField(quizKey)];
+  return typeof score === "number" && score >= 0 ? score : -1;
+}
+
 export async function getPreviousQuizScore(
   quizKey: QuizKey,
   actor: RequestActor,
   classroomCredential?: string,
 ): Promise<number> {
-  const principal = await resolveDataPrincipalFromCredential(classroomCredential, actor);
-  if (!principal.ok || !principal.value.ownerId) return -1;
+  try {
+    // Resolving the principal reads the participant and session collections, so the connection has
+    // to be open before that call, not merely before the quiz lookup.
+    await connectDB();
 
-  await connectDB();
-  const quiz = await Quiz.findOne({ clerkId: principal.value.ownerId }).lean<QuizBeforeScores | null>();
-  const score = quiz?.[getBeforeScoreField(quizKey)];
-  return typeof score === "number" ? score : -1;
+    const principal = await resolveDataPrincipalFromCredential(classroomCredential, actor);
+    if (!principal.ok || !principal.value.ownerId) return -1;
+
+    const score = await readBeforeScore(principal.value.ownerId, quizKey);
+    if (score >= 0 || principal.value.classroom || !actor.userId) return score;
+
+    // The classroom cookie can lapse while the student is still an active participant, in which
+    // case their baseline was written under the participant key and the personal record has
+    // nothing. Only consulted when the personal record has no score, so a real personal baseline
+    // is never overridden by a classroom one.
+    const participant = await findActiveClassroomParticipantForUser(actor.userId);
+    if (!participant) return -1;
+
+    return readBeforeScore(`participant:${participant.participantId}`, quizKey);
+  } catch (error) {
+    // "No previous score" is a state the quiz already renders. Letting a transient database error
+    // escape would fail the whole server-rendered page instead.
+    console.error("getPreviousQuizScore error:", error);
+    return -1;
+  }
 }

--- a/src/lib/server/quizProgress.ts
+++ b/src/lib/server/quizProgress.ts
@@ -1,10 +1,7 @@
 import connectDB from "@/database/db";
 import Quiz from "@/database/quizSchema";
 import { RequestActor } from "@/lib/server/apiAuthorization";
-import {
-  findActiveClassroomParticipantForUser,
-  resolveDataPrincipalFromCredential,
-} from "@/lib/server/classroomAuthorization";
+import { resolveDataPrincipalFromCredential } from "@/lib/server/classroomAuthorization";
 
 type QuizKey = "penguinRunQuiz" | "statesOfMatterQuiz";
 
@@ -17,12 +14,18 @@ function getBeforeScoreField(quizKey: QuizKey): keyof QuizBeforeScores {
   return quizKey === "penguinRunQuiz" ? "penguinRunScoreBefore" : "statesOfMatterScoreBefore";
 }
 
-async function readBeforeScore(ownerId: string, quizKey: QuizKey) {
-  const quiz = await Quiz.findOne({ clerkId: ownerId }).lean<QuizBeforeScores | null>();
-  const score = quiz?.[getBeforeScoreField(quizKey)];
-  return typeof score === "number" && score >= 0 ? score : -1;
-}
-
+/**
+ * Reads the baseline a student recorded before playing, for the principal that owns it.
+ *
+ * The owner is resolved from the classroom cookie or the signed-in user, and deliberately nothing
+ * else. A student whose classroom cookie has lapsed reads their personal record and sees no
+ * baseline, which is correct: `QuizExperience` derives the *write* owner from the localStorage
+ * snapshot, so the server cannot tell whether the matching after-score will be written to the
+ * participant record or the personal one. Recovering the classroom baseline here without the same
+ * signal on the write path would show the student a growth number against a record the result is
+ * never saved to, and leave the educator dashboard reporting no gain at all. Closing that gap needs
+ * the classroom context carried into the request, not inferred from it.
+ */
 export async function getPreviousQuizScore(
   quizKey: QuizKey,
   actor: RequestActor,
@@ -36,17 +39,10 @@ export async function getPreviousQuizScore(
     const principal = await resolveDataPrincipalFromCredential(classroomCredential, actor);
     if (!principal.ok || !principal.value.ownerId) return -1;
 
-    const score = await readBeforeScore(principal.value.ownerId, quizKey);
-    if (score >= 0 || principal.value.classroom || !actor.userId) return score;
+    const quiz = await Quiz.findOne({ clerkId: principal.value.ownerId }).lean<QuizBeforeScores | null>();
+    const score = quiz?.[getBeforeScoreField(quizKey)];
 
-    // The classroom cookie can lapse while the student is still an active participant, in which
-    // case their baseline was written under the participant key and the personal record has
-    // nothing. Only consulted when the personal record has no score, so a real personal baseline
-    // is never overridden by a classroom one.
-    const participant = await findActiveClassroomParticipantForUser(actor.userId);
-    if (!participant) return -1;
-
-    return readBeforeScore(`participant:${participant.participantId}`, quizKey);
+    return typeof score === "number" ? score : -1;
   } catch (error) {
     // "No previous score" is a state the quiz already renders. Letting a transient database error
     // escape would fail the whole server-rendered page instead.


### PR DESCRIPTION
## Summary
- resolve server-rendered after-quiz scores through the authenticated classroom cookie
- share the authorized principal lookup across Penguin Run and States of Matter
- preserve personal-player lookups and reject invalid guest credentials
- add coverage for personal, classroom, and unauthorized lookup paths

## Verification
- `npm test -- --run` passes: 27 tests
- `npm run lint` passes
- `next build` compiles, but prerendering requires the Clerk publishable key in the environment

Fixes #53