### PR TITLE
Let educators reopen classes and view classroom history

### DIFF
--- a/docs/api-authorization.md
+++ b/docs/api-authorization.md
@@ -14,31 +14,34 @@ Classroom records are keyed to the authorized participant, including for signed-
 
 ## Route Inventory
 
-| Route                          | Method           | Access                                                         |
-| ------------------------------ | ---------------- | -------------------------------------------------------------- |
-| `/api/admin/:id/role`          | PATCH            | Administrator                                                  |
-| `/api/auth/admin-access`       | GET              | Administrator                                                  |
-| `/api/classroom-sessions`      | GET, POST, PATCH | Signed-in educator; sessions are teacher-scoped                |
-| `/api/classroom-sessions/join` | POST             | Public with an active access code; issues classroom credential |
-| `/api/events`                  | GET              | Administrator                                                  |
-| `/api/events`                  | POST             | Signed-in session owner or credentialed classroom participant  |
-| `/api/example`                 | GET              | Administrator                                                  |
-| `/api/gameData`                | GET              | Administrator                                                  |
-| `/api/gameData`                | POST             | Signed-in owner or credentialed classroom participant          |
-| `/api/gameData/:saveId`        | GET              | Owner, administrator, or educator who owns the classroom       |
-| `/api/gameData/:saveId`        | PATCH            | Owner only                                                     |
-| `/api/quiz`                    | GET              | Administrator                                                  |
-| `/api/quiz`                    | POST             | Signed-in owner or credentialed classroom participant          |
-| `/api/quiz/:id`                | GET              | Owner, administrator, or educator who owns the classroom       |
-| `/api/quiz/:id`                | PUT              | Owner or administrator                                         |
-| `/api/sessions`                | GET              | Administrator                                                  |
-| `/api/sessions`                | POST             | Signed-in user; owner is derived from Clerk                    |
-| `/api/sessions/:sessionId`     | GET, PATCH       | Session owner or administrator                                 |
-| `/api/users`                   | GET              | Administrator                                                  |
-| `/api/users`                   | POST             | Signed-in user creating or refreshing their own record         |
-| `/api/users/:id`               | GET, PUT         | Administrator                                                  |
-| `/api/users/me`                | GET              | Signed-in user                                                 |
-| `/api/users/me/photo`          | PATCH            | Signed-in user                                                 |
+| Route                                             | Method           | Access                                                         |
+| ------------------------------------------------- | ---------------- | -------------------------------------------------------------- |
+| `/api/admin/:id/role`                             | PATCH            | Administrator                                                  |
+| `/api/auth/admin-access`                          | GET              | Administrator                                                  |
+| `/api/classroom-sessions`                         | GET, POST, PATCH | Signed-in educator; sessions are teacher-scoped                |
+| `/api/classroom-sessions/join`                    | POST             | Public with an active access code; issues classroom credential |
+| `/api/classroom-sessions/history`                 | GET              | Signed-in educator; only their own classes                     |
+| `/api/classroom-sessions/history/:classId`        | GET              | Educator who owns the class, or administrator                  |
+| `/api/classroom-sessions/history/:classId/reopen` | POST             | Owning educator only; no administrator bypass                  |
+| `/api/events`                                     | GET              | Administrator                                                  |
+| `/api/events`                                     | POST             | Signed-in session owner or credentialed classroom participant  |
+| `/api/example`                                    | GET              | Administrator                                                  |
+| `/api/gameData`                                   | GET              | Administrator                                                  |
+| `/api/gameData`                                   | POST             | Signed-in owner or credentialed classroom participant          |
+| `/api/gameData/:saveId`                           | GET              | Owner, administrator, or educator who owns the classroom       |
+| `/api/gameData/:saveId`                           | PATCH            | Owner only                                                     |
+| `/api/quiz`                                       | GET              | Administrator                                                  |
+| `/api/quiz`                                       | POST             | Signed-in owner or credentialed classroom participant          |
+| `/api/quiz/:id`                                   | GET              | Owner, administrator, or educator who owns the classroom       |
+| `/api/quiz/:id`                                   | PUT              | Owner or administrator                                         |
+| `/api/sessions`                                   | GET              | Administrator                                                  |
+| `/api/sessions`                                   | POST             | Signed-in user; owner is derived from Clerk                    |
+| `/api/sessions/:sessionId`                        | GET, PATCH       | Session owner or administrator                                 |
+| `/api/users`                                      | GET              | Administrator                                                  |
+| `/api/users`                                      | POST             | Signed-in user creating or refreshing their own record         |
+| `/api/users/:id`                                  | GET, PUT         | Administrator                                                  |
+| `/api/users/me`                                   | GET              | Signed-in user                                                 |
+| `/api/users/me/photo`                             | PATCH            | Signed-in user                                                 |
 
 ## Response Rules
 
@@ -47,3 +50,16 @@ Classroom records are keyed to the authorized participant, including for signed-
 - `404` is used for inaccessible individual resources so ownership cannot be inferred.
 - `400` is limited to malformed or unsupported input.
 - Unexpected errors return a generic `500` response; detailed failures remain in server logs.
+
+## Classroom History
+
+- A class is a chain of classroom sessions linked by `rootSessionId`, and is addressed by the id of
+  the session that started it. Reopening appends a linked continuation rather than reviving a closed
+  session, so historical records are never re-attributed.
+- Reads follow the usual rule: the owning educator, or an administrator. An inaccessible class
+  answers `404` rather than `403`, so one educator cannot probe for another's classes.
+- Reopening is deliberately narrower than reading. It requires educator standing and ownership, with
+  **no administrator bypass** — read access does not extend to changing who can join a class.
+- History responses carry projected views only. Stored records include Clerk ids, quiz ids, and
+  per-question answers, and a participant's `participantKey` embeds the student's Clerk id; none of
+  that crosses an API boundary.

--- a/src/app/api/classroom-sessions/history/[classId]/reopen/route.ts
+++ b/src/app/api/classroom-sessions/history/[classId]/reopen/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import connectDB from "@/database/db";
 import { reopenClassroomClass } from "@/lib/server/classroomClasses";
-import { getTeacherForCurrentUser } from "@/lib/server/educatorClassroom";
+import { findEducatorTeacher } from "@/lib/server/educatorClassroom";
 
 export async function POST(_request: Request, { params }: { params: Promise<{ classId: string }> }) {
   try {
@@ -15,12 +15,18 @@ export async function POST(_request: Request, { params }: { params: Promise<{ cl
     await connectDB();
 
     // Reopening changes who can join, so it stays with the owning educator. Admin read access does
-    // not extend to acting on another educator's class.
-    const teacherResult = await getTeacherForCurrentUser(userId);
-    if ("error" in teacherResult) return teacherResult.error;
+    // not extend to acting on another educator's class. The lookup is read-only: an educator with no
+    // Teacher record owns no classes, so there is nothing here to reopen and nothing to create.
+    const educator = await findEducatorTeacher(userId);
+    if (!educator) {
+      return NextResponse.json({ error: "Educator access required." }, { status: 403 });
+    }
+    if (!educator.teacherId) {
+      return NextResponse.json({ error: "Class not found." }, { status: 404 });
+    }
 
     const { classId } = await params;
-    const result = await reopenClassroomClass({ classId, teacherId: teacherResult.teacherId });
+    const result = await reopenClassroomClass({ classId, teacherId: educator.teacherId });
 
     if (!result.ok) {
       return NextResponse.json({ error: "Class not found." }, { status: 404 });

--- a/src/app/api/classroom-sessions/history/[classId]/reopen/route.ts
+++ b/src/app/api/classroom-sessions/history/[classId]/reopen/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import connectDB from "@/database/db";
+import { reopenClassroomClass } from "@/lib/server/classroomClasses";
+import { getTeacherForCurrentUser } from "@/lib/server/educatorClassroom";
+
+export async function POST(_request: Request, { params }: { params: Promise<{ classId: string }> }) {
+  try {
+    const { userId } = await auth();
+
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    await connectDB();
+
+    // Reopening changes who can join, so it stays with the owning educator. Admin read access does
+    // not extend to acting on another educator's class.
+    const teacherResult = await getTeacherForCurrentUser(userId);
+    if ("error" in teacherResult) return teacherResult.error;
+
+    const { classId } = await params;
+    const result = await reopenClassroomClass({ classId, teacherId: teacherResult.teacherId });
+
+    if (!result.ok) {
+      return NextResponse.json({ error: "Class not found." }, { status: 404 });
+    }
+
+    return NextResponse.json(
+      {
+        reopened: result.reopened,
+        classId: result.classId,
+        sessionId: result.sessionId,
+        accessCode: result.accessCode,
+        expiresAt: result.expiresAt,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.error("POST /api/classroom-sessions/history/:classId/reopen error:", error);
+    return NextResponse.json({ error: "Failed to reopen the class." }, { status: 500 });
+  }
+}

--- a/src/app/api/classroom-sessions/history/[classId]/route.ts
+++ b/src/app/api/classroom-sessions/history/[classId]/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import connectDB from "@/database/db";
+import { getRequestActor, unauthorized } from "@/lib/server/apiAuthorization";
+import { canEducatorReadClassroom } from "@/lib/server/classroomAuthorization";
+import { loadClassDetail } from "@/lib/server/classroomClasses";
+import { getTeacherForCurrentUser } from "@/lib/server/educatorClassroom";
+
+// Unauthorized reads answer 404 rather than 403 so one educator cannot probe for another's classes.
+const notFound = () => NextResponse.json({ error: "Class not found." }, { status: 404 });
+
+export async function GET(_request: Request, { params }: { params: Promise<{ classId: string }> }) {
+  try {
+    const actor = await getRequestActor();
+    if (!actor.userId) return unauthorized();
+
+    await connectDB();
+
+    const { classId } = await params;
+    if (!(await canEducatorReadClassroom(actor, classId))) return notFound();
+
+    // Admins already cleared authorization above and read across educators; everyone else stays
+    // scoped to the classes they own.
+    let teacherScope: string | null = null;
+    if (actor.role !== "admin") {
+      const teacherResult = await getTeacherForCurrentUser(actor.userId);
+      if ("error" in teacherResult) return teacherResult.error;
+      teacherScope = String(teacherResult.teacherId);
+    }
+
+    const detail = await loadClassDetail(classId, teacherScope);
+    if (!detail) return notFound();
+
+    return NextResponse.json({ class: detail }, { status: 200 });
+  } catch (error) {
+    console.error("GET /api/classroom-sessions/history/:classId error:", error);
+    return NextResponse.json({ error: "Failed to load class history." }, { status: 500 });
+  }
+}

--- a/src/app/api/classroom-sessions/history/[classId]/route.ts
+++ b/src/app/api/classroom-sessions/history/[classId]/route.ts
@@ -3,7 +3,7 @@ import connectDB from "@/database/db";
 import { getRequestActor, unauthorized } from "@/lib/server/apiAuthorization";
 import { canEducatorReadClassroom } from "@/lib/server/classroomAuthorization";
 import { loadClassDetail } from "@/lib/server/classroomClasses";
-import { getTeacherForCurrentUser } from "@/lib/server/educatorClassroom";
+import { findEducatorTeacher } from "@/lib/server/educatorClassroom";
 
 // Unauthorized reads answer 404 rather than 403 so one educator cannot probe for another's classes.
 const notFound = () => NextResponse.json({ error: "Class not found." }, { status: 404 });
@@ -22,9 +22,10 @@ export async function GET(_request: Request, { params }: { params: Promise<{ cla
     // scoped to the classes they own.
     let teacherScope: string | null = null;
     if (actor.role !== "admin") {
-      const teacherResult = await getTeacherForCurrentUser(actor.userId);
-      if ("error" in teacherResult) return teacherResult.error;
-      teacherScope = String(teacherResult.teacherId);
+      // Read-only: viewing a class must not create an educator profile as a side effect.
+      const educator = await findEducatorTeacher(actor.userId);
+      if (!educator?.teacherId) return notFound();
+      teacherScope = String(educator.teacherId);
     }
 
     const detail = await loadClassDetail(classId, teacherScope);

--- a/src/app/api/classroom-sessions/history/route.test.ts
+++ b/src/app/api/classroom-sessions/history/route.test.ts
@@ -22,6 +22,10 @@ vi.mock("@/lib/server/classroomClasses", () => ({
     const parsed = Number.parseInt(value ?? "", 10);
     return Number.isFinite(parsed) && parsed > 0 ? Math.min(parsed, 200) : 25;
   },
+  parseClassPageOffset: (value: string | null | undefined) => {
+    const parsed = Number.parseInt(value ?? "", 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+  },
   loadTeacherClassSummaries: mocks.loadTeacherClassSummaries,
   loadClassDetail: mocks.loadClassDetail,
   reopenClassroomClass: mocks.reopenClassroomClass,
@@ -65,7 +69,7 @@ function summary(overrides: Record<string, unknown> = {}) {
 describe("GET /api/classroom-sessions/history", () => {
   beforeEach(() => {
     mocks.findEducatorTeacher.mockResolvedValue({ name: "Educator", teacherId: TEACHER_ID });
-    mocks.loadTeacherClassSummaries.mockResolvedValue({ classes: [summary()], total: 1, hasMore: false });
+    mocks.loadTeacherClassSummaries.mockResolvedValue({ classes: [summary()], total: 1, offset: 0, hasMore: false });
   });
 
   it("rejects anonymous callers", async () => {
@@ -88,7 +92,7 @@ describe("GET /api/classroom-sessions/history", () => {
 
     const response = await listClasses(listRequest());
     expect(response.status).toBe(200);
-    expect(mocks.loadTeacherClassSummaries).toHaveBeenCalledWith(TEACHER_ID, expect.any(Date), 25);
+    expect(mocks.loadTeacherClassSummaries).toHaveBeenCalledWith(TEACHER_ID, expect.any(Date), 25, 0);
 
     const body = await response.json();
     expect(body.classes).toHaveLength(1);
@@ -98,7 +102,7 @@ describe("GET /api/classroom-sessions/history", () => {
 
   it("reports when older classes were left out rather than hiding them", async () => {
     mocks.auth.mockResolvedValue(EDUCATOR);
-    mocks.loadTeacherClassSummaries.mockResolvedValue({ classes: [summary()], total: 40, hasMore: true });
+    mocks.loadTeacherClassSummaries.mockResolvedValue({ classes: [summary()], total: 40, offset: 0, hasMore: true });
 
     const body = await (await listClasses(listRequest())).json();
 
@@ -110,7 +114,17 @@ describe("GET /api/classroom-sessions/history", () => {
 
     await listClasses(listRequest("?limit=5000"));
 
-    expect(mocks.loadTeacherClassSummaries).toHaveBeenCalledWith(TEACHER_ID, expect.any(Date), 200);
+    expect(mocks.loadTeacherClassSummaries).toHaveBeenCalledWith(TEACHER_ID, expect.any(Date), 200, 0);
+  });
+
+  it("pages deeper into history so older classes stay reachable", async () => {
+    mocks.auth.mockResolvedValue(EDUCATOR);
+    mocks.loadTeacherClassSummaries.mockResolvedValue({ classes: [summary()], total: 350, offset: 200, hasMore: true });
+
+    const body = await (await listClasses(listRequest("?offset=200"))).json();
+
+    expect(mocks.loadTeacherClassSummaries).toHaveBeenCalledWith(TEACHER_ID, expect.any(Date), 25, 200);
+    expect(body).toMatchObject({ total: 350, offset: 200, hasMore: true });
   });
 
   it("answers with an empty history for an educator who has never run a class", async () => {

--- a/src/app/api/classroom-sessions/history/route.test.ts
+++ b/src/app/api/classroom-sessions/history/route.test.ts
@@ -1,0 +1,197 @@
+import mongoose from "mongoose";
+import { NextResponse } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(),
+  connectDB: vi.fn(),
+  getTeacherForCurrentUser: vi.fn(),
+  canEducatorReadClassroom: vi.fn(),
+  loadTeacherClassSummaries: vi.fn(),
+  loadClassDetail: vi.fn(),
+  reopenClassroomClass: vi.fn(),
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({ auth: mocks.auth }));
+vi.mock("@/database/db", () => ({ default: mocks.connectDB }));
+vi.mock("@/lib/server/educatorClassroom", () => ({ getTeacherForCurrentUser: mocks.getTeacherForCurrentUser }));
+vi.mock("@/lib/server/classroomAuthorization", () => ({ canEducatorReadClassroom: mocks.canEducatorReadClassroom }));
+vi.mock("@/lib/server/classroomClasses", () => ({
+  loadTeacherClassSummaries: mocks.loadTeacherClassSummaries,
+  loadClassDetail: mocks.loadClassDetail,
+  reopenClassroomClass: mocks.reopenClassroomClass,
+}));
+
+import { GET as listClasses } from "@/app/api/classroom-sessions/history/route";
+import { GET as getClass } from "@/app/api/classroom-sessions/history/[classId]/route";
+import { POST as reopenClass } from "@/app/api/classroom-sessions/history/[classId]/reopen/route";
+
+const TEACHER_ID = new mongoose.Types.ObjectId();
+const CLASS_ID = String(new mongoose.Types.ObjectId());
+const params = Promise.resolve({ classId: CLASS_ID });
+
+const EDUCATOR = { userId: "user_educator", sessionClaims: { role: "educator" } };
+const ADMIN = { userId: "user_admin", sessionClaims: { role: "admin" } };
+const ANONYMOUS = { userId: null, sessionClaims: null };
+
+const forbiddenEducator = () => ({
+  error: NextResponse.json({ error: "Educator access required." }, { status: 403 }),
+});
+
+function summary(overrides: Record<string, unknown> = {}) {
+  return {
+    classId: CLASS_ID,
+    title: "4th Grade Science",
+    state: "closed",
+    createdAt: new Date(),
+    expiresAt: new Date(),
+    closedAt: new Date(),
+    sessions: [{}, {}],
+    reopenCount: 1,
+    participantCount: 3,
+    gamesPlayed: 2,
+    quizzesRecorded: 1,
+    averagePreQuizScore: 40,
+    averagePostQuizScore: 80,
+    lastActivityAt: new Date(),
+    activeAccessCode: null,
+    ...overrides,
+  };
+}
+
+describe("GET /api/classroom-sessions/history", () => {
+  beforeEach(() => {
+    mocks.getTeacherForCurrentUser.mockResolvedValue({ teacherId: TEACHER_ID });
+    mocks.loadTeacherClassSummaries.mockResolvedValue([summary()]);
+  });
+
+  it("rejects anonymous callers", async () => {
+    mocks.auth.mockResolvedValue(ANONYMOUS);
+
+    expect((await listClasses()).status).toBe(401);
+    expect(mocks.loadTeacherClassSummaries).not.toHaveBeenCalled();
+  });
+
+  it("rejects signed-in users who are not educators", async () => {
+    mocks.auth.mockResolvedValue({ userId: "user_player", sessionClaims: { role: "player" } });
+    mocks.getTeacherForCurrentUser.mockResolvedValue(forbiddenEducator());
+
+    expect((await listClasses()).status).toBe(403);
+    expect(mocks.loadTeacherClassSummaries).not.toHaveBeenCalled();
+  });
+
+  it("lists only the calling educator's classes", async () => {
+    mocks.auth.mockResolvedValue(EDUCATOR);
+
+    const response = await listClasses();
+    expect(response.status).toBe(200);
+    expect(mocks.loadTeacherClassSummaries).toHaveBeenCalledWith(TEACHER_ID);
+
+    const body = await response.json();
+    expect(body.classes).toHaveLength(1);
+    expect(body.classes[0]).toMatchObject({ classId: CLASS_ID, sessionCount: 2, reopenCount: 1 });
+  });
+});
+
+describe("GET /api/classroom-sessions/history/:classId", () => {
+  beforeEach(() => {
+    mocks.getTeacherForCurrentUser.mockResolvedValue({ teacherId: TEACHER_ID });
+    mocks.canEducatorReadClassroom.mockResolvedValue(true);
+    mocks.loadClassDetail.mockResolvedValue({ summary: summary(), roster: [] });
+  });
+
+  it("rejects anonymous callers", async () => {
+    mocks.auth.mockResolvedValue(ANONYMOUS);
+
+    expect((await getClass(new Request("http://localhost"), { params })).status).toBe(401);
+    expect(mocks.loadClassDetail).not.toHaveBeenCalled();
+  });
+
+  it("hides another educator's class behind a 404 instead of confirming it exists", async () => {
+    mocks.auth.mockResolvedValue(EDUCATOR);
+    mocks.canEducatorReadClassroom.mockResolvedValue(false);
+
+    const response = await getClass(new Request("http://localhost"), { params });
+
+    expect(response.status).toBe(404);
+    expect(mocks.loadClassDetail).not.toHaveBeenCalled();
+  });
+
+  it("scopes an educator's read to the classes they own", async () => {
+    mocks.auth.mockResolvedValue(EDUCATOR);
+
+    expect((await getClass(new Request("http://localhost"), { params })).status).toBe(200);
+    expect(mocks.loadClassDetail).toHaveBeenCalledWith(CLASS_ID, String(TEACHER_ID));
+  });
+
+  it("lets an admin read across educators without a teacher scope", async () => {
+    mocks.auth.mockResolvedValue(ADMIN);
+
+    expect((await getClass(new Request("http://localhost"), { params })).status).toBe(200);
+    expect(mocks.loadClassDetail).toHaveBeenCalledWith(CLASS_ID, null);
+    expect(mocks.getTeacherForCurrentUser).not.toHaveBeenCalled();
+  });
+
+  it("answers 404 when the class does not exist", async () => {
+    mocks.auth.mockResolvedValue(EDUCATOR);
+    mocks.loadClassDetail.mockResolvedValue(null);
+
+    expect((await getClass(new Request("http://localhost"), { params })).status).toBe(404);
+  });
+});
+
+describe("POST /api/classroom-sessions/history/:classId/reopen", () => {
+  beforeEach(() => {
+    mocks.getTeacherForCurrentUser.mockResolvedValue({ teacherId: TEACHER_ID });
+    mocks.reopenClassroomClass.mockResolvedValue({
+      ok: true,
+      reopened: true,
+      classId: CLASS_ID,
+      sessionId: "new-session",
+      accessCode: "NEWCODE-9Z8",
+      expiresAt: new Date(),
+    });
+  });
+
+  it("rejects anonymous callers", async () => {
+    mocks.auth.mockResolvedValue(ANONYMOUS);
+
+    expect((await reopenClass(new Request("http://localhost"), { params })).status).toBe(401);
+    expect(mocks.reopenClassroomClass).not.toHaveBeenCalled();
+  });
+
+  it("rejects signed-in users who are not educators", async () => {
+    mocks.auth.mockResolvedValue({ userId: "user_player", sessionClaims: { role: "player" } });
+    mocks.getTeacherForCurrentUser.mockResolvedValue(forbiddenEducator());
+
+    expect((await reopenClass(new Request("http://localhost"), { params })).status).toBe(403);
+    expect(mocks.reopenClassroomClass).not.toHaveBeenCalled();
+  });
+
+  it("offers admins no bypass: reopening still requires educator standing", async () => {
+    mocks.auth.mockResolvedValue(ADMIN);
+    mocks.getTeacherForCurrentUser.mockResolvedValue(forbiddenEducator());
+
+    expect((await reopenClass(new Request("http://localhost"), { params })).status).toBe(403);
+    expect(mocks.reopenClassroomClass).not.toHaveBeenCalled();
+    // The read-side admin bypass is never consulted here, so it cannot widen who may reopen.
+    expect(mocks.canEducatorReadClassroom).not.toHaveBeenCalled();
+  });
+
+  it("always reopens as the calling educator, never as the requested owner", async () => {
+    mocks.auth.mockResolvedValue(EDUCATOR);
+
+    const response = await reopenClass(new Request("http://localhost"), { params });
+
+    expect(response.status).toBe(200);
+    expect(mocks.reopenClassroomClass).toHaveBeenCalledWith({ classId: CLASS_ID, teacherId: TEACHER_ID });
+    await expect(response.json()).resolves.toMatchObject({ reopened: true, accessCode: "NEWCODE-9Z8" });
+  });
+
+  it("answers 404 when the class is not the educator's to reopen", async () => {
+    mocks.auth.mockResolvedValue(EDUCATOR);
+    mocks.reopenClassroomClass.mockResolvedValue({ ok: false, reason: "not_found" });
+
+    expect((await reopenClass(new Request("http://localhost"), { params })).status).toBe(404);
+  });
+});

--- a/src/app/api/classroom-sessions/history/route.test.ts
+++ b/src/app/api/classroom-sessions/history/route.test.ts
@@ -18,6 +18,10 @@ vi.mock("@/lib/server/educatorClassroom", () => ({ findEducatorTeacher: mocks.fi
 vi.mock("@/lib/server/classroomAuthorization", () => ({ canEducatorReadClassroom: mocks.canEducatorReadClassroom }));
 vi.mock("@/lib/server/classroomClasses", () => ({
   DEFAULT_CLASS_PAGE_SIZE: 25,
+  parseClassPageLimit: (value: string | null | undefined) => {
+    const parsed = Number.parseInt(value ?? "", 10);
+    return Number.isFinite(parsed) && parsed > 0 ? Math.min(parsed, 200) : 25;
+  },
   loadTeacherClassSummaries: mocks.loadTeacherClassSummaries,
   loadClassDetail: mocks.loadClassDetail,
   reopenClassroomClass: mocks.reopenClassroomClass,
@@ -89,6 +93,35 @@ describe("GET /api/classroom-sessions/history", () => {
     const body = await response.json();
     expect(body.classes).toHaveLength(1);
     expect(body.classes[0]).toMatchObject({ classId: CLASS_ID, sessionCount: 2, reopenCount: 1 });
+    expect(body).toMatchObject({ total: 1, hasMore: false, limit: 25 });
+  });
+
+  it("reports when older classes were left out rather than hiding them", async () => {
+    mocks.auth.mockResolvedValue(EDUCATOR);
+    mocks.loadTeacherClassSummaries.mockResolvedValue({ classes: [summary()], total: 40, hasMore: true });
+
+    const body = await (await listClasses(listRequest())).json();
+
+    expect(body).toMatchObject({ total: 40, hasMore: true });
+  });
+
+  it("honours an explicit limit but caps it", async () => {
+    mocks.auth.mockResolvedValue(EDUCATOR);
+
+    await listClasses(listRequest("?limit=5000"));
+
+    expect(mocks.loadTeacherClassSummaries).toHaveBeenCalledWith(TEACHER_ID, expect.any(Date), 200);
+  });
+
+  it("answers with an empty history for an educator who has never run a class", async () => {
+    mocks.auth.mockResolvedValue(EDUCATOR);
+    mocks.findEducatorTeacher.mockResolvedValue({ name: "Educator", teacherId: null });
+
+    const response = await listClasses(listRequest());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ classes: [], total: 0, hasMore: false });
+    expect(mocks.loadTeacherClassSummaries).not.toHaveBeenCalled();
   });
 });
 

--- a/src/app/api/classroom-sessions/history/route.test.ts
+++ b/src/app/api/classroom-sessions/history/route.test.ts
@@ -1,11 +1,11 @@
 import mongoose from "mongoose";
-import { NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   auth: vi.fn(),
   connectDB: vi.fn(),
-  getTeacherForCurrentUser: vi.fn(),
+  findEducatorTeacher: vi.fn(),
   canEducatorReadClassroom: vi.fn(),
   loadTeacherClassSummaries: vi.fn(),
   loadClassDetail: vi.fn(),
@@ -14,9 +14,10 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@clerk/nextjs/server", () => ({ auth: mocks.auth }));
 vi.mock("@/database/db", () => ({ default: mocks.connectDB }));
-vi.mock("@/lib/server/educatorClassroom", () => ({ getTeacherForCurrentUser: mocks.getTeacherForCurrentUser }));
+vi.mock("@/lib/server/educatorClassroom", () => ({ findEducatorTeacher: mocks.findEducatorTeacher }));
 vi.mock("@/lib/server/classroomAuthorization", () => ({ canEducatorReadClassroom: mocks.canEducatorReadClassroom }));
 vi.mock("@/lib/server/classroomClasses", () => ({
+  DEFAULT_CLASS_PAGE_SIZE: 25,
   loadTeacherClassSummaries: mocks.loadTeacherClassSummaries,
   loadClassDetail: mocks.loadClassDetail,
   reopenClassroomClass: mocks.reopenClassroomClass,
@@ -34,9 +35,7 @@ const EDUCATOR = { userId: "user_educator", sessionClaims: { role: "educator" } 
 const ADMIN = { userId: "user_admin", sessionClaims: { role: "admin" } };
 const ANONYMOUS = { userId: null, sessionClaims: null };
 
-const forbiddenEducator = () => ({
-  error: NextResponse.json({ error: "Educator access required." }, { status: 403 }),
-});
+const listRequest = (search = "") => new NextRequest(`http://localhost/api/classroom-sessions/history${search}`);
 
 function summary(overrides: Record<string, unknown> = {}) {
   return {
@@ -61,31 +60,31 @@ function summary(overrides: Record<string, unknown> = {}) {
 
 describe("GET /api/classroom-sessions/history", () => {
   beforeEach(() => {
-    mocks.getTeacherForCurrentUser.mockResolvedValue({ teacherId: TEACHER_ID });
-    mocks.loadTeacherClassSummaries.mockResolvedValue([summary()]);
+    mocks.findEducatorTeacher.mockResolvedValue({ name: "Educator", teacherId: TEACHER_ID });
+    mocks.loadTeacherClassSummaries.mockResolvedValue({ classes: [summary()], total: 1, hasMore: false });
   });
 
   it("rejects anonymous callers", async () => {
     mocks.auth.mockResolvedValue(ANONYMOUS);
 
-    expect((await listClasses()).status).toBe(401);
+    expect((await listClasses(listRequest())).status).toBe(401);
     expect(mocks.loadTeacherClassSummaries).not.toHaveBeenCalled();
   });
 
   it("rejects signed-in users who are not educators", async () => {
     mocks.auth.mockResolvedValue({ userId: "user_player", sessionClaims: { role: "player" } });
-    mocks.getTeacherForCurrentUser.mockResolvedValue(forbiddenEducator());
+    mocks.findEducatorTeacher.mockResolvedValue(null);
 
-    expect((await listClasses()).status).toBe(403);
+    expect((await listClasses(listRequest())).status).toBe(403);
     expect(mocks.loadTeacherClassSummaries).not.toHaveBeenCalled();
   });
 
   it("lists only the calling educator's classes", async () => {
     mocks.auth.mockResolvedValue(EDUCATOR);
 
-    const response = await listClasses();
+    const response = await listClasses(listRequest());
     expect(response.status).toBe(200);
-    expect(mocks.loadTeacherClassSummaries).toHaveBeenCalledWith(TEACHER_ID);
+    expect(mocks.loadTeacherClassSummaries).toHaveBeenCalledWith(TEACHER_ID, expect.any(Date), 25);
 
     const body = await response.json();
     expect(body.classes).toHaveLength(1);
@@ -95,7 +94,7 @@ describe("GET /api/classroom-sessions/history", () => {
 
 describe("GET /api/classroom-sessions/history/:classId", () => {
   beforeEach(() => {
-    mocks.getTeacherForCurrentUser.mockResolvedValue({ teacherId: TEACHER_ID });
+    mocks.findEducatorTeacher.mockResolvedValue({ name: "Educator", teacherId: TEACHER_ID });
     mocks.canEducatorReadClassroom.mockResolvedValue(true);
     mocks.loadClassDetail.mockResolvedValue({ summary: summary(), roster: [] });
   });
@@ -129,7 +128,7 @@ describe("GET /api/classroom-sessions/history/:classId", () => {
 
     expect((await getClass(new Request("http://localhost"), { params })).status).toBe(200);
     expect(mocks.loadClassDetail).toHaveBeenCalledWith(CLASS_ID, null);
-    expect(mocks.getTeacherForCurrentUser).not.toHaveBeenCalled();
+    expect(mocks.findEducatorTeacher).not.toHaveBeenCalled();
   });
 
   it("answers 404 when the class does not exist", async () => {
@@ -142,7 +141,7 @@ describe("GET /api/classroom-sessions/history/:classId", () => {
 
 describe("POST /api/classroom-sessions/history/:classId/reopen", () => {
   beforeEach(() => {
-    mocks.getTeacherForCurrentUser.mockResolvedValue({ teacherId: TEACHER_ID });
+    mocks.findEducatorTeacher.mockResolvedValue({ name: "Educator", teacherId: TEACHER_ID });
     mocks.reopenClassroomClass.mockResolvedValue({
       ok: true,
       reopened: true,
@@ -162,7 +161,7 @@ describe("POST /api/classroom-sessions/history/:classId/reopen", () => {
 
   it("rejects signed-in users who are not educators", async () => {
     mocks.auth.mockResolvedValue({ userId: "user_player", sessionClaims: { role: "player" } });
-    mocks.getTeacherForCurrentUser.mockResolvedValue(forbiddenEducator());
+    mocks.findEducatorTeacher.mockResolvedValue(null);
 
     expect((await reopenClass(new Request("http://localhost"), { params })).status).toBe(403);
     expect(mocks.reopenClassroomClass).not.toHaveBeenCalled();
@@ -170,7 +169,7 @@ describe("POST /api/classroom-sessions/history/:classId/reopen", () => {
 
   it("offers admins no bypass: reopening still requires educator standing", async () => {
     mocks.auth.mockResolvedValue(ADMIN);
-    mocks.getTeacherForCurrentUser.mockResolvedValue(forbiddenEducator());
+    mocks.findEducatorTeacher.mockResolvedValue(null);
 
     expect((await reopenClass(new Request("http://localhost"), { params })).status).toBe(403);
     expect(mocks.reopenClassroomClass).not.toHaveBeenCalled();

--- a/src/app/api/classroom-sessions/history/route.ts
+++ b/src/app/api/classroom-sessions/history/route.ts
@@ -1,7 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import connectDB from "@/database/db";
-import { DEFAULT_CLASS_PAGE_SIZE, loadTeacherClassSummaries, parseClassPageLimit } from "@/lib/server/classroomClasses";
+import {
+  DEFAULT_CLASS_PAGE_SIZE,
+  loadTeacherClassSummaries,
+  parseClassPageLimit,
+  parseClassPageOffset,
+} from "@/lib/server/classroomClasses";
 import { findEducatorTeacher } from "@/lib/server/educatorClassroom";
 
 export async function GET(request: NextRequest) {
@@ -23,13 +28,14 @@ export async function GET(request: NextRequest) {
     // An educator with no Teacher record has simply never run a class.
     if (!educator.teacherId) {
       return NextResponse.json(
-        { classes: [], total: 0, hasMore: false, limit: DEFAULT_CLASS_PAGE_SIZE },
+        { classes: [], total: 0, offset: 0, hasMore: false, limit: DEFAULT_CLASS_PAGE_SIZE },
         { status: 200 },
       );
     }
 
     const limit = parseClassPageLimit(request.nextUrl.searchParams.get("limit"));
-    const page = await loadTeacherClassSummaries(educator.teacherId, new Date(), limit);
+    const offset = parseClassPageOffset(request.nextUrl.searchParams.get("offset"));
+    const page = await loadTeacherClassSummaries(educator.teacherId, new Date(), limit, offset);
 
     return NextResponse.json(
       {
@@ -51,6 +57,7 @@ export async function GET(request: NextRequest) {
           activeAccessCode: summary.activeAccessCode,
         })),
         total: page.total,
+        offset: page.offset,
         hasMore: page.hasMore,
         limit,
       },

--- a/src/app/api/classroom-sessions/history/route.ts
+++ b/src/app/api/classroom-sessions/history/route.ts
@@ -1,16 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import connectDB from "@/database/db";
-import { DEFAULT_CLASS_PAGE_SIZE, loadTeacherClassSummaries } from "@/lib/server/classroomClasses";
+import { DEFAULT_CLASS_PAGE_SIZE, loadTeacherClassSummaries, parseClassPageLimit } from "@/lib/server/classroomClasses";
 import { findEducatorTeacher } from "@/lib/server/educatorClassroom";
-
-const MAX_CLASS_PAGE_SIZE = 200;
-
-function parseLimit(value: string | null) {
-  const parsed = Number.parseInt(value ?? "", 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_CLASS_PAGE_SIZE;
-  return Math.min(parsed, MAX_CLASS_PAGE_SIZE);
-}
 
 export async function GET(request: NextRequest) {
   try {
@@ -36,7 +28,7 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const limit = parseLimit(request.nextUrl.searchParams.get("limit"));
+    const limit = parseClassPageLimit(request.nextUrl.searchParams.get("limit"));
     const page = await loadTeacherClassSummaries(educator.teacherId, new Date(), limit);
 
     return NextResponse.json(

--- a/src/app/api/classroom-sessions/history/route.ts
+++ b/src/app/api/classroom-sessions/history/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import connectDB from "@/database/db";
+import { loadTeacherClassSummaries } from "@/lib/server/classroomClasses";
+import { getTeacherForCurrentUser } from "@/lib/server/educatorClassroom";
+
+export async function GET() {
+  try {
+    const { userId } = await auth();
+
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    await connectDB();
+
+    const teacherResult = await getTeacherForCurrentUser(userId);
+    if ("error" in teacherResult) return teacherResult.error;
+
+    const summaries = await loadTeacherClassSummaries(teacherResult.teacherId);
+
+    return NextResponse.json(
+      {
+        classes: summaries.map((summary) => ({
+          classId: summary.classId,
+          title: summary.title,
+          state: summary.state,
+          createdAt: summary.createdAt,
+          expiresAt: summary.expiresAt,
+          closedAt: summary.closedAt,
+          sessionCount: summary.sessions.length,
+          reopenCount: summary.reopenCount,
+          participantCount: summary.participantCount,
+          gamesPlayed: summary.gamesPlayed,
+          quizzesRecorded: summary.quizzesRecorded,
+          averagePreQuizScore: summary.averagePreQuizScore,
+          averagePostQuizScore: summary.averagePostQuizScore,
+          lastActivityAt: summary.lastActivityAt,
+          activeAccessCode: summary.activeAccessCode,
+        })),
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.error("GET /api/classroom-sessions/history error:", error);
+    return NextResponse.json({ error: "Failed to load classroom history." }, { status: 500 });
+  }
+}

--- a/src/app/api/classroom-sessions/history/route.ts
+++ b/src/app/api/classroom-sessions/history/route.ts
@@ -1,10 +1,18 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import connectDB from "@/database/db";
-import { loadTeacherClassSummaries } from "@/lib/server/classroomClasses";
-import { getTeacherForCurrentUser } from "@/lib/server/educatorClassroom";
+import { DEFAULT_CLASS_PAGE_SIZE, loadTeacherClassSummaries } from "@/lib/server/classroomClasses";
+import { findEducatorTeacher } from "@/lib/server/educatorClassroom";
 
-export async function GET() {
+const MAX_CLASS_PAGE_SIZE = 200;
+
+function parseLimit(value: string | null) {
+  const parsed = Number.parseInt(value ?? "", 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_CLASS_PAGE_SIZE;
+  return Math.min(parsed, MAX_CLASS_PAGE_SIZE);
+}
+
+export async function GET(request: NextRequest) {
   try {
     const { userId } = await auth();
 
@@ -14,14 +22,26 @@ export async function GET() {
 
     await connectDB();
 
-    const teacherResult = await getTeacherForCurrentUser(userId);
-    if ("error" in teacherResult) return teacherResult.error;
+    // Read-only lookup: listing classes must not create an educator profile as a side effect.
+    const educator = await findEducatorTeacher(userId);
+    if (!educator) {
+      return NextResponse.json({ error: "Educator access required." }, { status: 403 });
+    }
 
-    const summaries = await loadTeacherClassSummaries(teacherResult.teacherId);
+    // An educator with no Teacher record has simply never run a class.
+    if (!educator.teacherId) {
+      return NextResponse.json(
+        { classes: [], total: 0, hasMore: false, limit: DEFAULT_CLASS_PAGE_SIZE },
+        { status: 200 },
+      );
+    }
+
+    const limit = parseLimit(request.nextUrl.searchParams.get("limit"));
+    const page = await loadTeacherClassSummaries(educator.teacherId, new Date(), limit);
 
     return NextResponse.json(
       {
-        classes: summaries.map((summary) => ({
+        classes: page.classes.map((summary) => ({
           classId: summary.classId,
           title: summary.title,
           state: summary.state,
@@ -38,6 +58,9 @@ export async function GET() {
           lastActivityAt: summary.lastActivityAt,
           activeAccessCode: summary.activeAccessCode,
         })),
+        total: page.total,
+        hasMore: page.hasMore,
+        limit,
       },
       { status: 200 },
     );

--- a/src/app/api/classroom-sessions/route.ts
+++ b/src/app/api/classroom-sessions/route.ts
@@ -5,19 +5,13 @@ import connectDB from "@/database/db";
 import ClassroomSession from "@/database/classroomSessionSchema";
 import StudentAccessCode from "@/database/studentAccessCodeSchema";
 import ClassroomParticipant from "@/database/classroomParticipantSchema";
-import Teacher from "@/database/teacherSchema";
-import User from "@/database/userSchema";
-
-const SESSION_DURATION_MS = 8 * 60 * 60 * 1000;
-
-function generateAccessCode() {
-  const letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-  const alphanumeric = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-  const pick = (source: string, count: number) =>
-    Array.from({ length: count }, () => source[Math.floor(Math.random() * source.length)]).join("");
-
-  return `${pick(letters, 6)}-${pick(alphanumeric, 3)}`;
-}
+import { getClassId } from "@/lib/server/classroomHistory";
+import {
+  SESSION_DURATION_MS,
+  closeActiveClassroomSessions,
+  getTeacherForCurrentUser,
+  issueAccessCode,
+} from "@/lib/server/educatorClassroom";
 
 async function buildSessionPayload(sessionId: mongoose.Types.ObjectId | string) {
   const [session, accessCode, participants] = await Promise.all([
@@ -28,6 +22,7 @@ async function buildSessionPayload(sessionId: mongoose.Types.ObjectId | string) 
       createdAt: Date;
       expiresAt: Date;
       closedAt: Date | null;
+      rootSessionId?: mongoose.Types.ObjectId | null;
     } | null>(),
     StudentAccessCode.findOne({ sessionId, isActive: true }).lean<{
       _id: mongoose.Types.ObjectId;
@@ -48,6 +43,7 @@ async function buildSessionPayload(sessionId: mongoose.Types.ObjectId | string) 
 
   return {
     sessionId: String(session._id),
+    classId: getClassId(session),
     title: session.title,
     status: session.status,
     accessCode: accessCode.code,
@@ -61,35 +57,6 @@ async function buildSessionPayload(sessionId: mongoose.Types.ObjectId | string) 
       lastSeenAt: participant.lastSeenAt,
     })),
   };
-}
-
-async function getTeacherForCurrentUser(userId: string) {
-  const dbUser = await User.findOne({ clerkId: userId }).lean<{
-    name?: string;
-    email?: string;
-    role?: string;
-  } | null>();
-
-  if (dbUser?.role !== "educator") {
-    return { error: NextResponse.json({ error: "Educator access required." }, { status: 403 }) };
-  }
-
-  const teacher = await Teacher.findOneAndUpdate(
-    { clerkId: userId },
-    {
-      $set: {
-        name: dbUser.name ?? "Educator",
-        email: dbUser.email ?? `${userId}@example.invalid`,
-      },
-    },
-    { new: true, upsert: true, setDefaultsOnInsert: true, runValidators: true },
-  ).lean<{ _id: mongoose.Types.ObjectId } | null>();
-
-  if (!teacher) {
-    return { error: NextResponse.json({ error: "Unable to create educator profile." }, { status: 500 }) };
-  }
-
-  return { teacherId: teacher._id };
 }
 
 export async function GET() {
@@ -142,24 +109,7 @@ export async function POST(request: NextRequest) {
     const requestedTitle = typeof body.title === "string" ? body.title.trim() : "";
     const title = requestedTitle || "Untitled Class";
 
-    const existingActiveSessions = await ClassroomSession.find({
-      teacherId: teacherResult.teacherId,
-      status: "active",
-    }).lean<Array<{ _id: mongoose.Types.ObjectId }>>();
-
-    if (existingActiveSessions.length > 0) {
-      const existingIds = existingActiveSessions.map((session) => session._id);
-      await Promise.all([
-        ClassroomSession.updateMany(
-          { _id: { $in: existingIds } },
-          { $set: { status: "closed", closedAt: new Date() } },
-        ),
-        StudentAccessCode.updateMany(
-          { sessionId: { $in: existingIds }, isActive: true },
-          { $set: { isActive: false } },
-        ),
-      ]);
-    }
+    await closeActiveClassroomSessions(teacherResult.teacherId);
 
     const session = await ClassroomSession.create({
       teacherId: teacherResult.teacherId,
@@ -167,19 +117,7 @@ export async function POST(request: NextRequest) {
       expiresAt: new Date(Date.now() + SESSION_DURATION_MS),
     });
 
-    let accessCode = "";
-    for (let attempt = 0; attempt < 5; attempt += 1) {
-      try {
-        accessCode = generateAccessCode();
-        await StudentAccessCode.create({
-          sessionId: session._id,
-          code: accessCode,
-        });
-        break;
-      } catch (error: any) {
-        if (error?.code !== 11000 || attempt === 4) throw error;
-      }
-    }
+    await issueAccessCode(session._id);
 
     const payload = await buildSessionPayload(session._id);
     return NextResponse.json({ session: payload }, { status: 201 });

--- a/src/app/educatorClassHistory/ReopenClassButton.tsx
+++ b/src/app/educatorClassHistory/ReopenClassButton.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import styles from "./educatorClassHistory.module.css";
+
+type ReopenResponse = {
+  error?: string;
+  reopened?: boolean;
+  accessCode?: string | null;
+};
+
+export default function ReopenClassButton({ classId, className }: { classId: string; className: string }) {
+  const router = useRouter();
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState("");
+  const [accessCode, setAccessCode] = useState<string | null>(null);
+
+  const handleReopen = async () => {
+    setPending(true);
+    setError("");
+
+    try {
+      const response = await fetch(`/api/classroom-sessions/history/${encodeURIComponent(classId)}/reopen`, {
+        method: "POST",
+      });
+      const result = (await response.json()) as ReopenResponse;
+
+      if (!response.ok) {
+        throw new Error(result.error || "Unable to reopen this class.");
+      }
+
+      setAccessCode(result.accessCode ?? null);
+      router.refresh();
+    } catch (caughtError) {
+      setError(caughtError instanceof Error ? caughtError.message : "Unable to reopen this class.");
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <div className={styles.reopenPanel}>
+      <button type="button" className={styles.reopenButton} onClick={handleReopen} disabled={pending}>
+        {pending ? "Reopening..." : "Reopen class"}
+      </button>
+      <p className={styles.mutedText}>
+        Reopening {className} starts a new session linked to this class. Past rosters, game saves, and quiz results stay
+        exactly as they are, and any other class you have open will be closed.
+      </p>
+      {accessCode ? (
+        <p className={styles.reopenSuccess} role="status">
+          Class reopened. New access code: <span className={styles.accessCodeInline}>{accessCode}</span>
+        </p>
+      ) : null}
+      {error ? (
+        <p className={styles.reopenError} role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/educatorClassHistory/ReopenClassButton.tsx
+++ b/src/app/educatorClassHistory/ReopenClassButton.tsx
@@ -27,7 +27,9 @@ export default function ReopenClassButton({ classId, className }: { classId: str
       const response = await fetch(`/api/classroom-sessions/history/${encodeURIComponent(classId)}/reopen`, {
         method: "POST",
       });
-      const result = (await response.json()) as ReopenResponse;
+      // Parsed defensively: an upstream 502 or auth interstitial returns HTML, and letting
+      // JSON.parse throw would show the educator "Unexpected token '<'".
+      const result = (await response.json().catch(() => ({}))) as ReopenResponse;
 
       if (!response.ok) {
         throw new Error(result.error || "Unable to reopen this class.");

--- a/src/app/educatorClassHistory/ReopenClassButton.tsx
+++ b/src/app/educatorClassHistory/ReopenClassButton.tsx
@@ -14,7 +14,7 @@ export default function ReopenClassButton({ classId, className }: { classId: str
   const router = useRouter();
   const [pending, setPending] = useState(false);
   const [error, setError] = useState("");
-  const [accessCode, setAccessCode] = useState<string | null>(null);
+  const [outcome, setOutcome] = useState<{ reopened: boolean; accessCode: string | null } | null>(null);
 
   const handleReopen = async () => {
     setPending(true);
@@ -30,7 +30,9 @@ export default function ReopenClassButton({ classId, className }: { classId: str
         throw new Error(result.error || "Unable to reopen this class.");
       }
 
-      setAccessCode(result.accessCode ?? null);
+      // `reopened: false` means the class was already live — a stale page, a second tab, or a
+      // double submit. Saying "reopened" there would claim an action that never happened.
+      setOutcome({ reopened: Boolean(result.reopened), accessCode: result.accessCode ?? null });
       router.refresh();
     } catch (caughtError) {
       setError(caughtError instanceof Error ? caughtError.message : "Unable to reopen this class.");
@@ -48,9 +50,17 @@ export default function ReopenClassButton({ classId, className }: { classId: str
         Reopening {className} starts a new session linked to this class. Past rosters, game saves, and quiz results stay
         exactly as they are, and any other class you have open will be closed.
       </p>
-      {accessCode ? (
+      {outcome ? (
         <p className={styles.reopenSuccess} role="status">
-          Class reopened. New access code: <span className={styles.accessCodeInline}>{accessCode}</span>
+          {outcome.reopened ? "Class reopened." : "This class was already open."}{" "}
+          {outcome.accessCode ? (
+            <>
+              {outcome.reopened ? "New access code" : "Access code"}:{" "}
+              <span className={styles.accessCodeInline}>{outcome.accessCode}</span>
+            </>
+          ) : (
+            "Refresh to see its current access code."
+          )}
         </p>
       ) : null}
       {error ? (

--- a/src/app/educatorClassHistory/ReopenClassButton.tsx
+++ b/src/app/educatorClassHistory/ReopenClassButton.tsx
@@ -19,6 +19,9 @@ export default function ReopenClassButton({ classId, className }: { classId: str
   const handleReopen = async () => {
     setPending(true);
     setError("");
+    // A previous success must not stay on screen next to a new failure — it would show an access
+    // code the failed request never issued.
+    setOutcome(null);
 
     try {
       const response = await fetch(`/api/classroom-sessions/history/${encodeURIComponent(classId)}/reopen`, {

--- a/src/app/educatorClassHistory/[classId]/page.tsx
+++ b/src/app/educatorClassHistory/[classId]/page.tsx
@@ -1,0 +1,246 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { auth } from "@clerk/nextjs/server";
+import connectDB from "@/database/db";
+import { loadClassDetail } from "@/lib/server/classroomClasses";
+import { getGameLabel } from "@/lib/server/classroomHistory";
+import { findEducatorTeacher } from "@/lib/server/educatorClassroom";
+import { PENGUIN_RUN_QUESTION_COUNT, STATES_OF_MATTER_QUESTION_COUNT, normalizeQuizScore } from "@/lib/quizScoring";
+import ReopenClassButton from "../ReopenClassButton";
+import { STATE_BADGE_CLASS, STATE_LABELS, formatDateTime, formatScore } from "../formatting";
+import styles from "../educatorClassHistory.module.css";
+
+export const dynamic = "force-dynamic";
+
+const ACTIVITY_LIMIT = 12;
+
+export default async function EducatorClassDetailPage({ params }: { params: Promise<{ classId: string }> }) {
+  const { userId } = await auth();
+  if (!userId) return null;
+
+  await connectDB();
+
+  const educator = await findEducatorTeacher(userId);
+  if (!educator) return null;
+
+  const { classId } = await params;
+  const detail = await loadClassDetail(classId, educator.teacherId);
+  if (!detail) notFound();
+
+  const { summary, roster, sessionStates, gameData, quizzes, activity } = detail;
+  const recentActivity = activity.slice(0, ACTIVITY_LIMIT);
+
+  return (
+    <main className={styles.shell}>
+      <section className={styles.main}>
+        <div className={styles.headerRow}>
+          <div className={styles.headerCopy}>
+            <Link href="/educatorClassHistory" className={styles.backLink}>
+              ← Back to class history
+            </Link>
+            <h1 className={styles.title}>{summary.title}</h1>
+            <p className={styles.subtitle}>
+              Started {formatDateTime(summary.createdAt)} · {summary.sessions.length} session
+              {summary.sessions.length === 1 ? "" : "s"}
+              {summary.reopenCount > 0
+                ? ` · reopened ${summary.reopenCount} time${summary.reopenCount === 1 ? "" : "s"}`
+                : ""}
+            </p>
+          </div>
+          <span className={`${styles.badge} ${STATE_BADGE_CLASS[summary.state]}`}>{STATE_LABELS[summary.state]}</span>
+        </div>
+
+        <div className={styles.statGrid}>
+          <div className={styles.stat}>
+            <p className={styles.statLabel}>Students</p>
+            <p className={styles.statValue}>{summary.participantCount}</p>
+          </div>
+          <div className={styles.stat}>
+            <p className={styles.statLabel}>Games Played</p>
+            <p className={styles.statValue}>{summary.gamesPlayed}</p>
+          </div>
+          <div className={styles.stat}>
+            <p className={styles.statLabel}>Quiz Records</p>
+            <p className={styles.statValue}>{summary.quizzesRecorded}</p>
+          </div>
+          <div className={styles.stat}>
+            <p className={styles.statLabel}>Avg. Pre-Quiz</p>
+            <p className={styles.statValue}>{formatScore(summary.averagePreQuizScore)}</p>
+          </div>
+          <div className={styles.stat}>
+            <p className={styles.statLabel}>Avg. Post-Quiz</p>
+            <p className={styles.statValue}>{formatScore(summary.averagePostQuizScore)}</p>
+          </div>
+        </div>
+
+        <section className={styles.card}>
+          <h2 className={styles.cardTitle}>Access</h2>
+          {summary.state === "active" ? (
+            <p className={styles.mutedText}>
+              This class is live until {formatDateTime(summary.expiresAt)}. Students can join with{" "}
+              <span className={styles.accessCodeInline}>{summary.activeAccessCode ?? "—"}</span>.
+            </p>
+          ) : (
+            <ReopenClassButton classId={summary.classId} className={summary.title} />
+          )}
+        </section>
+
+        <section className={styles.card}>
+          <h2 className={styles.cardTitle}>Session timeline</h2>
+          <div className={styles.timeline}>
+            {sessionStates.map((session, index) => (
+              <article key={session.sessionId} className={styles.timelineItem}>
+                <div className={styles.timelineHeader}>
+                  <p className={styles.timelineLabel}>{index === 0 ? "Original session" : `Continuation ${index}`}</p>
+                  <span className={`${styles.badge} ${STATE_BADGE_CLASS[session.state]}`}>
+                    {STATE_LABELS[session.state]}
+                  </span>
+                </div>
+                <p className={styles.classMeta}>
+                  Opened {formatDateTime(session.createdAt)} · expires {formatDateTime(session.expiresAt)}
+                  {session.closedAt ? ` · closed ${formatDateTime(session.closedAt)}` : ""}
+                </p>
+                {session.accessCodes.length ? (
+                  <ul className={styles.codeList}>
+                    {session.accessCodes.map((accessCode) => (
+                      <li key={accessCode.code} className={styles.codeItem}>
+                        <span className={accessCode.isActive ? styles.codeValue : styles.codeRetired}>
+                          {accessCode.code}
+                        </span>{" "}
+                        {accessCode.isActive ? "active" : "retired"}
+                        {accessCode.lastSeenAt ? ` · last used ${formatDateTime(accessCode.lastSeenAt)}` : ""}
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className={styles.classMeta}>No access code issued.</p>
+                )}
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className={styles.card}>
+          <h2 className={styles.cardTitle}>Roster</h2>
+          {roster.length ? (
+            <div className={styles.tableWrap}>
+              <table className={styles.table}>
+                <thead>
+                  <tr>
+                    <th scope="col">Student</th>
+                    <th scope="col">First joined</th>
+                    <th scope="col">Last seen</th>
+                    <th scope="col">Sessions attended</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {roster.map((entry) => (
+                    <tr key={entry.participantKey}>
+                      <td>{entry.displayName}</td>
+                      <td>{formatDateTime(entry.joinedAt)}</td>
+                      <td>{formatDateTime(entry.lastSeenAt)}</td>
+                      <td>{entry.sessionIds.length}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <p className={styles.mutedText}>No students joined this class.</p>
+          )}
+        </section>
+
+        <section className={styles.card}>
+          <h2 className={styles.cardTitle}>Quiz results</h2>
+          {quizzes.length ? (
+            <div className={styles.tableWrap}>
+              <table className={styles.table}>
+                <thead>
+                  <tr>
+                    <th scope="col">Student</th>
+                    <th scope="col">States pre</th>
+                    <th scope="col">States post</th>
+                    <th scope="col">Penguin pre</th>
+                    <th scope="col">Penguin post</th>
+                    <th scope="col">Updated</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {quizzes.map((quiz) => (
+                    <tr key={String(quiz._id)}>
+                      <td>{quiz.studentDisplayName || "A student"}</td>
+                      <td>
+                        {formatScore(
+                          normalizeQuizScore(quiz.statesOfMatterScoreBefore, STATES_OF_MATTER_QUESTION_COUNT),
+                        )}
+                      </td>
+                      <td>
+                        {formatScore(normalizeQuizScore(quiz.stateOfMatterScoreAfter, STATES_OF_MATTER_QUESTION_COUNT))}
+                      </td>
+                      <td>{formatScore(normalizeQuizScore(quiz.penguinRunScoreBefore, PENGUIN_RUN_QUESTION_COUNT))}</td>
+                      <td>{formatScore(normalizeQuizScore(quiz.penguinRunScoreAfter, PENGUIN_RUN_QUESTION_COUNT))}</td>
+                      <td>{formatDateTime(quiz.updatedAt)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <p className={styles.mutedText}>No quiz results were recorded for this class.</p>
+          )}
+        </section>
+
+        <section className={styles.card}>
+          <h2 className={styles.cardTitle}>Game progress</h2>
+          {gameData.length ? (
+            <div className={styles.tableWrap}>
+              <table className={styles.table}>
+                <thead>
+                  <tr>
+                    <th scope="col">Student</th>
+                    <th scope="col">Game</th>
+                    <th scope="col">Levels completed</th>
+                    <th scope="col">Stages completed</th>
+                    <th scope="col">Last updated</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {gameData.map((game) => (
+                    <tr key={String(game._id)}>
+                      <td>{game.studentDisplayName || "A student"}</td>
+                      <td>{getGameLabel(game.gameId)}</td>
+                      <td>{game.completedLevels?.length ?? 0}</td>
+                      <td>{game.completedStageIds?.length ?? 0}</td>
+                      <td>{formatDateTime(game.lastUpdated)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <p className={styles.mutedText}>No game progress was saved for this class.</p>
+          )}
+        </section>
+
+        <section className={styles.card}>
+          <h2 className={styles.cardTitle}>Recent activity</h2>
+          {recentActivity.length ? (
+            <div className={styles.activityList}>
+              {recentActivity.map((item) => (
+                <article key={item.id} className={styles.activityItem}>
+                  <div className={styles.activityDot} aria-hidden="true" />
+                  <div className={styles.activityContent}>
+                    <p className={styles.activityDescription}>{item.description}</p>
+                    <p className={styles.mutedText}>{formatDateTime(item.occurredAt)}</p>
+                  </div>
+                </article>
+              ))}
+            </div>
+          ) : (
+            <p className={styles.mutedText}>Nothing has happened in this class yet.</p>
+          )}
+        </section>
+      </section>
+    </main>
+  );
+}

--- a/src/app/educatorClassHistory/[classId]/page.tsx
+++ b/src/app/educatorClassHistory/[classId]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 import connectDB from "@/database/db";
 import { getRequestActor } from "@/lib/server/apiAuthorization";
 import { canEducatorReadClassroom } from "@/lib/server/classroomAuthorization";
-import { loadClassDetail } from "@/lib/server/classroomClasses";
+import { DEFAULT_ACTIVITY_LIMIT, loadClassDetail } from "@/lib/server/classroomClasses";
 import { findEducatorTeacher } from "@/lib/server/educatorClassroom";
 import { PENGUIN_RUN_QUESTION_COUNT, STATES_OF_MATTER_QUESTION_COUNT, normalizeQuizScore } from "@/lib/quizScoring";
 import ReopenClassButton from "../ReopenClassButton";
@@ -12,7 +12,7 @@ import styles from "../educatorClassHistory.module.css";
 
 export const dynamic = "force-dynamic";
 
-const ACTIVITY_LIMIT = 12;
+const ACTIVITY_LIMIT = DEFAULT_ACTIVITY_LIMIT;
 
 export default async function EducatorClassDetailPage({ params }: { params: Promise<{ classId: string }> }) {
   const actor = await getRequestActor();
@@ -33,8 +33,12 @@ export default async function EducatorClassDetailPage({ params }: { params: Prom
     teacherScope = String(educator.teacherId);
   }
 
-  const detail = await loadClassDetail(classId, teacherScope);
+  const detail = await loadClassDetail(classId, teacherScope, new Date(), ACTIVITY_LIMIT);
   if (!detail) notFound();
+
+  // Reopening deliberately has no admin bypass, so only the owning educator gets the control.
+  // Rendering it for an admin would offer an action that always fails.
+  const canReopen = teacherScope !== null;
 
   const { summary, roster, sessionStates, gameData, quizzes, activity } = detail;
   const recentActivity = activity.slice(0, ACTIVITY_LIMIT);
@@ -49,8 +53,8 @@ export default async function EducatorClassDetailPage({ params }: { params: Prom
             </Link>
             <h1 className={styles.title}>{summary.title}</h1>
             <p className={styles.subtitle}>
-              Started {formatDateTime(summary.createdAt)} · {summary.sessions.length} session
-              {summary.sessions.length === 1 ? "" : "s"}
+              Started {formatDateTime(summary.createdAt)} · {summary.sessionCount} session
+              {summary.sessionCount === 1 ? "" : "s"}
               {summary.reopenCount > 0
                 ? ` · reopened ${summary.reopenCount} time${summary.reopenCount === 1 ? "" : "s"}`
                 : ""}
@@ -89,8 +93,12 @@ export default async function EducatorClassDetailPage({ params }: { params: Prom
               This class is live until {formatDateTime(summary.expiresAt)}. Students can join with{" "}
               <span className={styles.accessCodeInline}>{summary.activeAccessCode ?? "—"}</span>.
             </p>
-          ) : (
+          ) : canReopen ? (
             <ReopenClassButton classId={summary.classId} className={summary.title} />
+          ) : (
+            <p className={styles.mutedText}>
+              This class is {STATE_LABELS[summary.state].toLowerCase()}. Only the educator who owns it can reopen it.
+            </p>
           )}
         </section>
 

--- a/src/app/educatorClassHistory/[classId]/page.tsx
+++ b/src/app/educatorClassHistory/[classId]/page.tsx
@@ -1,9 +1,9 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { auth } from "@clerk/nextjs/server";
 import connectDB from "@/database/db";
+import { getRequestActor } from "@/lib/server/apiAuthorization";
+import { canEducatorReadClassroom } from "@/lib/server/classroomAuthorization";
 import { loadClassDetail } from "@/lib/server/classroomClasses";
-import { getGameLabel } from "@/lib/server/classroomHistory";
 import { findEducatorTeacher } from "@/lib/server/educatorClassroom";
 import { PENGUIN_RUN_QUESTION_COUNT, STATES_OF_MATTER_QUESTION_COUNT, normalizeQuizScore } from "@/lib/quizScoring";
 import ReopenClassButton from "../ReopenClassButton";
@@ -15,16 +15,25 @@ export const dynamic = "force-dynamic";
 const ACTIVITY_LIMIT = 12;
 
 export default async function EducatorClassDetailPage({ params }: { params: Promise<{ classId: string }> }) {
-  const { userId } = await auth();
-  if (!userId) return null;
+  const actor = await getRequestActor();
+  if (!actor.userId) return null;
 
   await connectDB();
 
-  const educator = await findEducatorTeacher(userId);
-  if (!educator) return null;
-
   const { classId } = await params;
-  const detail = await loadClassDetail(classId, educator.teacherId);
+  if (!(await canEducatorReadClassroom(actor, classId))) notFound();
+
+  // Mirrors the API route: admins read across educators, everyone else stays scoped to their own
+  // classes. Without the admin branch this page would render blank for the very admins the
+  // corresponding endpoint grants access to.
+  let teacherScope: string | null = null;
+  if (actor.role !== "admin") {
+    const educator = await findEducatorTeacher(actor.userId);
+    if (!educator?.teacherId) notFound();
+    teacherScope = String(educator.teacherId);
+  }
+
+  const detail = await loadClassDetail(classId, teacherScope);
   if (!detail) notFound();
 
   const { summary, roster, sessionStates, gameData, quizzes, activity } = detail;
@@ -135,11 +144,11 @@ export default async function EducatorClassDetailPage({ params }: { params: Prom
                 </thead>
                 <tbody>
                   {roster.map((entry) => (
-                    <tr key={entry.participantKey}>
+                    <tr key={entry.id}>
                       <td>{entry.displayName}</td>
                       <td>{formatDateTime(entry.joinedAt)}</td>
                       <td>{formatDateTime(entry.lastSeenAt)}</td>
-                      <td>{entry.sessionIds.length}</td>
+                      <td>{entry.sessionCount}</td>
                     </tr>
                   ))}
                 </tbody>
@@ -167,7 +176,7 @@ export default async function EducatorClassDetailPage({ params }: { params: Prom
                 </thead>
                 <tbody>
                   {quizzes.map((quiz) => (
-                    <tr key={String(quiz._id)}>
+                    <tr key={quiz.id}>
                       <td>{quiz.studentDisplayName || "A student"}</td>
                       <td>
                         {formatScore(
@@ -206,11 +215,11 @@ export default async function EducatorClassDetailPage({ params }: { params: Prom
                 </thead>
                 <tbody>
                   {gameData.map((game) => (
-                    <tr key={String(game._id)}>
+                    <tr key={game.id}>
                       <td>{game.studentDisplayName || "A student"}</td>
-                      <td>{getGameLabel(game.gameId)}</td>
-                      <td>{game.completedLevels?.length ?? 0}</td>
-                      <td>{game.completedStageIds?.length ?? 0}</td>
+                      <td>{game.gameLabel}</td>
+                      <td>{game.completedLevelCount}</td>
+                      <td>{game.completedStageCount}</td>
                       <td>{formatDateTime(game.lastUpdated)}</td>
                     </tr>
                   ))}

--- a/src/app/educatorClassHistory/educatorClassHistory.module.css
+++ b/src/app/educatorClassHistory/educatorClassHistory.module.css
@@ -1,0 +1,502 @@
+.shell {
+  min-height: 100vh;
+  background: #ffffff;
+  width: 100%;
+}
+
+.main {
+  width: 100%;
+  min-height: calc(100vh - 64px);
+  margin: 0;
+  padding: 28px clamp(24px, 4.2vw, 56px) 56px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 18px;
+  background: radial-gradient(circle at top right, rgba(193, 221, 255, 0.45), transparent 28%),
+    linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+}
+
+.headerRow {
+  width: 100%;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.headerCopy {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.backLink {
+  font-family: "Karla", "Avenir Next", "Segoe UI", sans-serif;
+  font-size: 15px;
+  font-weight: 700;
+  color: #4476bb;
+  text-decoration: none;
+}
+
+.backLink:hover {
+  text-decoration: underline;
+}
+
+.title {
+  margin: 0;
+  font-family: "Poppins", "Trebuchet MS", "Avenir Next", sans-serif;
+  font-weight: 700;
+  font-size: 36px;
+  line-height: 48px;
+  color: #1b1b1b;
+}
+
+.subtitle {
+  margin: 0;
+  max-width: 860px;
+  font-family: "Poppins", "Trebuchet MS", "Avenir Next", sans-serif;
+  font-weight: 400;
+  font-size: 18px;
+  line-height: 28px;
+  color: #747474;
+}
+
+.primaryLink {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  padding: 0 20px;
+  border-radius: 14px;
+  background: #2a256f;
+  color: #ffffff;
+  font-family: "Karla", "Avenir Next", "Segoe UI", sans-serif;
+  font-size: 16px;
+  font-weight: 700;
+  text-decoration: none;
+  white-space: nowrap;
+  box-shadow: 0 14px 28px rgba(42, 37, 111, 0.16);
+}
+
+.primaryLink:hover {
+  background: #231f60;
+}
+
+.card {
+  width: 100%;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 18px;
+  background: #ffffff;
+  border: 1px solid #dbe6f6;
+  border-radius: 16px;
+  box-shadow: 0 18px 36px rgba(45, 73, 133, 0.06);
+}
+
+.cardTitle {
+  margin: 0;
+  font-family: "Poppins", "Trebuchet MS", "Avenir Next", sans-serif;
+  font-weight: 600;
+  font-size: 20px;
+  line-height: 30px;
+  color: #1b1b1b;
+}
+
+.mutedText {
+  margin: 0;
+  font-family: "Karla", "Avenir Next", "Segoe UI", sans-serif;
+  font-size: 15px;
+  line-height: 1.45;
+  color: #6b7280;
+}
+
+.classList {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.classCard {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 20px 22px;
+  border-radius: 16px;
+  border: 1px solid #dbe6f6;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+  box-shadow: 0 16px 34px rgba(45, 73, 133, 0.06);
+}
+
+.classCardHeader {
+  width: 100%;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.classHeading {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 0;
+}
+
+.classTitle {
+  margin: 0;
+  font-family: "Poppins", "Trebuchet MS", "Avenir Next", sans-serif;
+  font-weight: 600;
+  font-size: 20px;
+  line-height: 28px;
+  color: #1b1b1b;
+}
+
+.classMeta {
+  margin: 0;
+  font-family: "Karla", "Avenir Next", "Segoe UI", sans-serif;
+  font-size: 15px;
+  line-height: 1.45;
+  color: #6b7280;
+}
+
+.classActions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  height: 28px;
+  padding: 0 12px;
+  border-radius: 999px;
+  font-family: "Karla", "Avenir Next", "Segoe UI", sans-serif;
+  font-size: 13px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.badgeActive {
+  background: #e7f6ec;
+  border-color: #b7e0c4;
+  color: #1f7a44;
+}
+
+.badgeExpired {
+  background: #fdf3e2;
+  border-color: #f0d5a4;
+  color: #8a5b12;
+}
+
+.badgeClosed {
+  background: #f1f3f7;
+  border-color: #dbe0ea;
+  color: #5a6376;
+}
+
+.statGrid {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.stat {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: #f8fbff;
+  border: 1px solid #e3ebf8;
+}
+
+.statLabel {
+  margin: 0;
+  font-family: "Karla", "Avenir Next", "Segoe UI", sans-serif;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #5a74ba;
+}
+
+.statValue {
+  margin: 0;
+  font-family: "Poppins", "Trebuchet MS", "Avenir Next", sans-serif;
+  font-weight: 700;
+  font-size: 22px;
+  line-height: 1.2;
+  color: #1b1b1b;
+}
+
+.detailLink {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 42px;
+  padding: 0 18px;
+  border-radius: 12px;
+  border: 1px solid #c9d9f2;
+  background: #ffffff;
+  color: #2a256f;
+  font-family: "Karla", "Avenir Next", "Segoe UI", sans-serif;
+  font-size: 15px;
+  font-weight: 700;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.detailLink:hover {
+  background: #eef4ff;
+}
+
+.accessCodeInline {
+  font-family: "Poppins", "Trebuchet MS", "Avenir Next", sans-serif;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  color: #243f95;
+}
+
+.timeline {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.timelineItem {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: #f8fbff;
+  border: 1px solid #e3ebf8;
+}
+
+.timelineHeader {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.timelineLabel {
+  margin: 0;
+  font-family: "Poppins", "Trebuchet MS", "Avenir Next", sans-serif;
+  font-weight: 600;
+  font-size: 16px;
+  color: #1b1b1b;
+}
+
+.codeList {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.codeItem {
+  font-family: "Karla", "Avenir Next", "Segoe UI", sans-serif;
+  font-size: 14px;
+  color: #6b7280;
+}
+
+.codeValue {
+  font-family: "Poppins", "Trebuchet MS", "Avenir Next", sans-serif;
+  font-weight: 700;
+  color: #243f95;
+}
+
+.codeRetired {
+  color: #98a2b3;
+  text-decoration: line-through;
+}
+
+.tableWrap {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: "Karla", "Avenir Next", "Segoe UI", sans-serif;
+  font-size: 15px;
+  color: #23262f;
+}
+
+.table th,
+.table td {
+  padding: 10px 12px;
+  text-align: left;
+  border-bottom: 1px solid #e3ebf8;
+  white-space: nowrap;
+}
+
+.table th {
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #5a74ba;
+}
+
+.table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.activityList {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.activityItem {
+  width: 100%;
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: #f8fbff;
+  border: 1px solid #e3ebf8;
+}
+
+.activityDot {
+  width: 12px;
+  height: 12px;
+  margin-top: 6px;
+  border-radius: 999px;
+  background: #4476bb;
+  flex-shrink: 0;
+}
+
+.activityContent {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.activityDescription {
+  margin: 0;
+  font-family: "Karla", "Avenir Next", "Segoe UI", sans-serif;
+  font-size: 17px;
+  line-height: 1.45;
+  color: #23262f;
+}
+
+.reopenPanel {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: flex-start;
+}
+
+.reopenButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  padding: 0 22px;
+  border: none;
+  border-radius: 14px;
+  background: #2a256f;
+  color: #ffffff;
+  font-family: "Karla", "Avenir Next", "Segoe UI", sans-serif;
+  font-size: 16px;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 14px 28px rgba(42, 37, 111, 0.16);
+}
+
+.reopenButton:hover:not(:disabled) {
+  background: #231f60;
+}
+
+.reopenButton:disabled {
+  background: #9aa2c4;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.reopenError {
+  margin: 0;
+  font-family: "Karla", "Avenir Next", "Segoe UI", sans-serif;
+  font-size: 15px;
+  color: #b42318;
+}
+
+.reopenSuccess {
+  margin: 0;
+  font-family: "Karla", "Avenir Next", "Segoe UI", sans-serif;
+  font-size: 15px;
+  color: #1f7a44;
+}
+
+@media (max-width: 900px) {
+  .main {
+    padding: 24px 20px 40px;
+  }
+
+  .headerRow {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .primaryLink {
+    width: 100%;
+  }
+
+  .title {
+    font-size: 30px;
+    line-height: 40px;
+  }
+
+  .subtitle {
+    font-size: 16px;
+    line-height: 24px;
+  }
+
+  .statGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .card {
+    padding: 20px;
+  }
+}
+
+@media (max-width: 640px) {
+  .statGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Timestamps need to fit the same tile as a two-digit count without wrapping the card. */
+.statValueSmall {
+  margin: 0;
+  font-family: "Poppins", "Trebuchet MS", "Avenir Next", sans-serif;
+  font-weight: 600;
+  font-size: 15px;
+  line-height: 1.35;
+  color: #1b1b1b;
+}

--- a/src/app/educatorClassHistory/educatorClassHistory.module.css
+++ b/src/app/educatorClassHistory/educatorClassHistory.module.css
@@ -500,3 +500,12 @@
   line-height: 1.35;
   color: #1b1b1b;
 }
+
+.pager {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  padding-top: 4px;
+}

--- a/src/app/educatorClassHistory/formatting.ts
+++ b/src/app/educatorClassHistory/formatting.ts
@@ -1,0 +1,30 @@
+import { ClassroomSessionState } from "@/lib/server/classroomHistory";
+import styles from "./educatorClassHistory.module.css";
+
+export const STATE_LABELS: Record<ClassroomSessionState, string> = {
+  active: "Active",
+  expired: "Expired",
+  closed: "Closed",
+};
+
+export const STATE_BADGE_CLASS: Record<ClassroomSessionState, string> = {
+  active: styles.badgeActive,
+  expired: styles.badgeExpired,
+  closed: styles.badgeClosed,
+};
+
+export function formatDateTime(value: Date | null | undefined) {
+  if (!value) return "—";
+
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(value);
+}
+
+export function formatScore(value: number | null) {
+  return value === null ? "—" : `${Math.round(value)}%`;
+}

--- a/src/app/educatorClassHistory/page.tsx
+++ b/src/app/educatorClassHistory/page.tsx
@@ -1,7 +1,12 @@
 import Link from "next/link";
 import { auth } from "@clerk/nextjs/server";
 import connectDB from "@/database/db";
-import { MAX_CLASS_PAGE_SIZE, loadTeacherClassSummaries, parseClassPageLimit } from "@/lib/server/classroomClasses";
+import {
+  DEFAULT_CLASS_PAGE_SIZE,
+  loadTeacherClassSummaries,
+  parseClassPageLimit,
+  parseClassPageOffset,
+} from "@/lib/server/classroomClasses";
 import { findEducatorTeacher } from "@/lib/server/educatorClassroom";
 import { STATE_BADGE_CLASS, STATE_LABELS, formatDateTime, formatScore } from "./formatting";
 import styles from "./educatorClassHistory.module.css";
@@ -9,7 +14,7 @@ import styles from "./educatorClassHistory.module.css";
 export const dynamic = "force-dynamic";
 
 type ClassHistoryPageProps = {
-  searchParams?: Promise<{ limit?: string }>;
+  searchParams?: Promise<{ limit?: string; offset?: string }>;
 };
 
 export default async function EducatorClassHistoryPage({ searchParams }: ClassHistoryPageProps) {
@@ -21,14 +26,24 @@ export default async function EducatorClassHistoryPage({ searchParams }: ClassHi
   const educator = await findEducatorTeacher(userId);
   if (!educator) return null;
 
-  const limit = parseClassPageLimit((await searchParams)?.limit);
+  const params = await searchParams;
+  const limit = parseClassPageLimit(params?.limit);
+  const requestedOffset = parseClassPageOffset(params?.offset);
 
   // An educator with no Teacher record yet has simply never run a class, so fall through to the
   // empty state rather than rendering a blank document.
   const page = educator.teacherId
-    ? await loadTeacherClassSummaries(educator.teacherId, new Date(), limit)
-    : { classes: [], total: 0, hasMore: false };
-  const { classes, total, hasMore } = page;
+    ? await loadTeacherClassSummaries(educator.teacherId, new Date(), limit, requestedOffset)
+    : { classes: [], total: 0, offset: 0, hasMore: false };
+  const { classes, total, offset, hasMore } = page;
+
+  const pageHref = (nextOffset: number) => {
+    const search = new URLSearchParams();
+    if (limit !== DEFAULT_CLASS_PAGE_SIZE) search.set("limit", String(limit));
+    if (nextOffset > 0) search.set("offset", String(nextOffset));
+    const query = search.toString();
+    return query ? `/educatorClassHistory?${query}` : "/educatorClassHistory";
+  };
 
   return (
     <main className={styles.shell}>
@@ -40,8 +55,8 @@ export default async function EducatorClassHistoryPage({ searchParams }: ClassHi
             </Link>
             <h1 className={styles.title}>Class History</h1>
             <p className={styles.subtitle}>
-              {hasMore
-                ? `Showing your ${classes.length} most recent classes of ${total}.`
+              {total > classes.length
+                ? `Showing ${offset + 1}–${offset + classes.length} of ${total} classes, newest first.`
                 : "Every class you have run, including the ones that have closed or expired."}{" "}
               Open a class to review its roster, game activity, and quiz results, or reopen it to keep going.
             </p>
@@ -118,13 +133,19 @@ export default async function EducatorClassHistoryPage({ searchParams }: ClassHi
                 </div>
               </article>
             ))}
-            {hasMore ? (
-              <Link
-                href={`/educatorClassHistory?limit=${Math.min(total, MAX_CLASS_PAGE_SIZE)}`}
-                className={styles.detailLink}
-              >
-                Show all {total} classes
-              </Link>
+            {offset > 0 || hasMore ? (
+              <div className={styles.pager}>
+                {offset > 0 ? (
+                  <Link href={pageHref(Math.max(0, offset - limit))} className={styles.detailLink}>
+                    ← Newer classes
+                  </Link>
+                ) : null}
+                {hasMore ? (
+                  <Link href={pageHref(offset + limit)} className={styles.detailLink}>
+                    Older classes →
+                  </Link>
+                ) : null}
+              </div>
             ) : null}
           </div>
         )}

--- a/src/app/educatorClassHistory/page.tsx
+++ b/src/app/educatorClassHistory/page.tsx
@@ -17,7 +17,9 @@ export default async function EducatorClassHistoryPage() {
   const educator = await findEducatorTeacher(userId);
   if (!educator) return null;
 
-  const classes = await loadTeacherClassSummaries(educator.teacherId);
+  // An educator with no Teacher record yet has simply never run a class, so fall through to the
+  // empty state rather than rendering a blank document.
+  const classes = educator.teacherId ? await loadTeacherClassSummaries(educator.teacherId) : [];
 
   return (
     <main className={styles.shell}>

--- a/src/app/educatorClassHistory/page.tsx
+++ b/src/app/educatorClassHistory/page.tsx
@@ -1,14 +1,26 @@
 import Link from "next/link";
 import { auth } from "@clerk/nextjs/server";
 import connectDB from "@/database/db";
-import { loadTeacherClassSummaries } from "@/lib/server/classroomClasses";
+import { DEFAULT_CLASS_PAGE_SIZE, loadTeacherClassSummaries } from "@/lib/server/classroomClasses";
 import { findEducatorTeacher } from "@/lib/server/educatorClassroom";
 import { STATE_BADGE_CLASS, STATE_LABELS, formatDateTime, formatScore } from "./formatting";
 import styles from "./educatorClassHistory.module.css";
 
 export const dynamic = "force-dynamic";
 
-export default async function EducatorClassHistoryPage() {
+const MAX_CLASS_PAGE_SIZE = 200;
+
+type ClassHistoryPageProps = {
+  searchParams?: Promise<{ limit?: string }>;
+};
+
+function parseLimit(value: string | undefined) {
+  const parsed = Number.parseInt(value ?? "", 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_CLASS_PAGE_SIZE;
+  return Math.min(parsed, MAX_CLASS_PAGE_SIZE);
+}
+
+export default async function EducatorClassHistoryPage({ searchParams }: ClassHistoryPageProps) {
   const { userId } = await auth();
   if (!userId) return null;
 
@@ -17,9 +29,14 @@ export default async function EducatorClassHistoryPage() {
   const educator = await findEducatorTeacher(userId);
   if (!educator) return null;
 
+  const limit = parseLimit((await searchParams)?.limit);
+
   // An educator with no Teacher record yet has simply never run a class, so fall through to the
   // empty state rather than rendering a blank document.
-  const classes = educator.teacherId ? await loadTeacherClassSummaries(educator.teacherId) : [];
+  const page = educator.teacherId
+    ? await loadTeacherClassSummaries(educator.teacherId, new Date(), limit)
+    : { classes: [], total: 0, hasMore: false };
+  const { classes, total, hasMore } = page;
 
   return (
     <main className={styles.shell}>
@@ -31,8 +48,10 @@ export default async function EducatorClassHistoryPage() {
             </Link>
             <h1 className={styles.title}>Class History</h1>
             <p className={styles.subtitle}>
-              Every class you have run, including the ones that have closed or expired. Open a class to review its
-              roster, game activity, and quiz results, or reopen it to keep going.
+              {hasMore
+                ? `Showing your ${classes.length} most recent classes of ${total}.`
+                : "Every class you have run, including the ones that have closed or expired."}{" "}
+              Open a class to review its roster, game activity, and quiz results, or reopen it to keep going.
             </p>
           </div>
           <Link href="/educatorCreateClass?fresh=1" className={styles.primaryLink}>
@@ -107,6 +126,14 @@ export default async function EducatorClassHistoryPage() {
                 </div>
               </article>
             ))}
+            {hasMore ? (
+              <Link
+                href={`/educatorClassHistory?limit=${Math.min(total, MAX_CLASS_PAGE_SIZE)}`}
+                className={styles.detailLink}
+              >
+                Show all {total} classes
+              </Link>
+            ) : null}
           </div>
         )}
       </section>

--- a/src/app/educatorClassHistory/page.tsx
+++ b/src/app/educatorClassHistory/page.tsx
@@ -1,24 +1,16 @@
 import Link from "next/link";
 import { auth } from "@clerk/nextjs/server";
 import connectDB from "@/database/db";
-import { DEFAULT_CLASS_PAGE_SIZE, loadTeacherClassSummaries } from "@/lib/server/classroomClasses";
+import { MAX_CLASS_PAGE_SIZE, loadTeacherClassSummaries, parseClassPageLimit } from "@/lib/server/classroomClasses";
 import { findEducatorTeacher } from "@/lib/server/educatorClassroom";
 import { STATE_BADGE_CLASS, STATE_LABELS, formatDateTime, formatScore } from "./formatting";
 import styles from "./educatorClassHistory.module.css";
 
 export const dynamic = "force-dynamic";
 
-const MAX_CLASS_PAGE_SIZE = 200;
-
 type ClassHistoryPageProps = {
   searchParams?: Promise<{ limit?: string }>;
 };
-
-function parseLimit(value: string | undefined) {
-  const parsed = Number.parseInt(value ?? "", 10);
-  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_CLASS_PAGE_SIZE;
-  return Math.min(parsed, MAX_CLASS_PAGE_SIZE);
-}
 
 export default async function EducatorClassHistoryPage({ searchParams }: ClassHistoryPageProps) {
   const { userId } = await auth();
@@ -29,7 +21,7 @@ export default async function EducatorClassHistoryPage({ searchParams }: ClassHi
   const educator = await findEducatorTeacher(userId);
   if (!educator) return null;
 
-  const limit = parseLimit((await searchParams)?.limit);
+  const limit = parseClassPageLimit((await searchParams)?.limit);
 
   // An educator with no Teacher record yet has simply never run a class, so fall through to the
   // empty state rather than rendering a blank document.

--- a/src/app/educatorClassHistory/page.tsx
+++ b/src/app/educatorClassHistory/page.tsx
@@ -1,0 +1,113 @@
+import Link from "next/link";
+import { auth } from "@clerk/nextjs/server";
+import connectDB from "@/database/db";
+import { loadTeacherClassSummaries } from "@/lib/server/classroomClasses";
+import { findEducatorTeacher } from "@/lib/server/educatorClassroom";
+import { STATE_BADGE_CLASS, STATE_LABELS, formatDateTime, formatScore } from "./formatting";
+import styles from "./educatorClassHistory.module.css";
+
+export const dynamic = "force-dynamic";
+
+export default async function EducatorClassHistoryPage() {
+  const { userId } = await auth();
+  if (!userId) return null;
+
+  await connectDB();
+
+  const educator = await findEducatorTeacher(userId);
+  if (!educator) return null;
+
+  const classes = await loadTeacherClassSummaries(educator.teacherId);
+
+  return (
+    <main className={styles.shell}>
+      <section className={styles.main}>
+        <div className={styles.headerRow}>
+          <div className={styles.headerCopy}>
+            <Link href="/educatorDashboard" className={styles.backLink}>
+              ← Back to dashboard
+            </Link>
+            <h1 className={styles.title}>Class History</h1>
+            <p className={styles.subtitle}>
+              Every class you have run, including the ones that have closed or expired. Open a class to review its
+              roster, game activity, and quiz results, or reopen it to keep going.
+            </p>
+          </div>
+          <Link href="/educatorCreateClass?fresh=1" className={styles.primaryLink}>
+            Start New Class
+          </Link>
+        </div>
+
+        {classes.length === 0 ? (
+          <section className={styles.card}>
+            <h2 className={styles.cardTitle}>No classes yet</h2>
+            <p className={styles.mutedText}>
+              Once you start a class and students join, it will appear here — and stay here after it closes.
+            </p>
+          </section>
+        ) : (
+          <div className={styles.classList}>
+            {classes.map((summary) => (
+              <article key={summary.classId} className={styles.classCard}>
+                <div className={styles.classCardHeader}>
+                  <div className={styles.classHeading}>
+                    <h2 className={styles.classTitle}>{summary.title}</h2>
+                    <p className={styles.classMeta}>
+                      Started {formatDateTime(summary.createdAt)}
+                      {summary.reopenCount > 0
+                        ? ` · reopened ${summary.reopenCount} time${summary.reopenCount === 1 ? "" : "s"}`
+                        : ""}
+                      {summary.state === "active"
+                        ? ` · expires ${formatDateTime(summary.expiresAt)}`
+                        : summary.state === "closed"
+                          ? ` · closed ${formatDateTime(summary.closedAt)}`
+                          : ` · expired ${formatDateTime(summary.expiresAt)}`}
+                    </p>
+                    {summary.activeAccessCode ? (
+                      <p className={styles.classMeta}>
+                        Active access code: <span className={styles.accessCodeInline}>{summary.activeAccessCode}</span>
+                      </p>
+                    ) : (
+                      <p className={styles.classMeta}>No active access code. Reopen the class to issue a new one.</p>
+                    )}
+                  </div>
+                  <div className={styles.classActions}>
+                    <span className={`${styles.badge} ${STATE_BADGE_CLASS[summary.state]}`}>
+                      {STATE_LABELS[summary.state]}
+                    </span>
+                    <Link href={`/educatorClassHistory/${summary.classId}`} className={styles.detailLink}>
+                      View class
+                    </Link>
+                  </div>
+                </div>
+
+                <div className={styles.statGrid}>
+                  <div className={styles.stat}>
+                    <p className={styles.statLabel}>Students</p>
+                    <p className={styles.statValue}>{summary.participantCount}</p>
+                  </div>
+                  <div className={styles.stat}>
+                    <p className={styles.statLabel}>Games Played</p>
+                    <p className={styles.statValue}>{summary.gamesPlayed}</p>
+                  </div>
+                  <div className={styles.stat}>
+                    <p className={styles.statLabel}>Avg. Pre-Quiz</p>
+                    <p className={styles.statValue}>{formatScore(summary.averagePreQuizScore)}</p>
+                  </div>
+                  <div className={styles.stat}>
+                    <p className={styles.statLabel}>Avg. Post-Quiz</p>
+                    <p className={styles.statValue}>{formatScore(summary.averagePostQuizScore)}</p>
+                  </div>
+                  <div className={styles.stat}>
+                    <p className={styles.statLabel}>Last Activity</p>
+                    <p className={styles.statValueSmall}>{formatDateTime(summary.lastActivityAt)}</p>
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/src/app/educatorDashboard/educatorDashboard.module.css
+++ b/src/app/educatorDashboard/educatorDashboard.module.css
@@ -71,6 +71,56 @@
   background: #231f60;
 }
 
+.headerActions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.secondaryButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 48px;
+  padding: 0 20px;
+  border-radius: 14px;
+  border: 1px solid #c9d9f2;
+  background: #ffffff;
+  color: #2a256f;
+  font-family: "Karla", "Avenir Next", "Segoe UI", sans-serif;
+  font-size: 16px;
+  font-weight: 700;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.secondaryButton:hover {
+  background: #eef4ff;
+}
+
+.activityHeader {
+  width: 100%;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.activityLink {
+  font-family: "Karla", "Avenir Next", "Segoe UI", sans-serif;
+  font-size: 15px;
+  font-weight: 700;
+  color: #4476bb;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.activityLink:hover {
+  text-decoration: underline;
+}
+
 .accessCodeCard {
   width: 100%;
   padding: 22px 24px;
@@ -245,7 +295,14 @@
     align-items: stretch;
   }
 
-  .restartButton {
+  .headerActions {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .restartButton,
+  .secondaryButton {
     width: 100%;
   }
 

--- a/src/app/educatorDashboard/page.tsx
+++ b/src/app/educatorDashboard/page.tsx
@@ -7,122 +7,31 @@ import Quiz from "@/database/quizSchema";
 import StudentAccessCode from "@/database/studentAccessCodeSchema";
 import Teacher from "@/database/teacherSchema";
 import User from "@/database/userSchema";
-import quizData from "@/data/quiz.json";
+import { formatPercent, getAveragePostQuizScore, getAveragePreQuizScore } from "@/lib/quizScoring";
+import {
+  ClassroomGameRecord,
+  ClassroomParticipantRecord,
+  ClassroomQuizRecord,
+  buildClassroomActivity,
+  getClassId,
+} from "@/lib/server/classroomHistory";
 import Link from "next/link";
 import DashboardAutoRefresh from "./DashboardAutoRefresh";
 import styles from "./educatorDashboard.module.css";
 
-type ActivityItem = {
-  id: string;
-  description: string;
-  occurredAt: Date;
-};
+const ACTIVITY_LIMIT = 8;
 
-const typedQuizData = quizData as {
-  penguinRunQuiz?: unknown[];
-  statesOfMatterQuiz?: unknown[];
-};
-
-const PENGUIN_RUN_QUESTION_COUNT = typedQuizData.penguinRunQuiz?.length || 1;
-const STATES_OF_MATTER_QUESTION_COUNT = typedQuizData.statesOfMatterQuiz?.length || 1;
-
-function formatPercent(value: number) {
-  return `${Math.round(value)}%`;
-}
-
-function getAveragePreQuizScore(
-  quizzes: Array<{
-    statesOfMatterScoreBefore?: number;
-    penguinRunScoreBefore?: number;
-  }>,
-) {
-  const scores = quizzes.flatMap((quiz) => {
-    const normalizedScores = [
-      typeof quiz.statesOfMatterScoreBefore === "number" && quiz.statesOfMatterScoreBefore >= 0
-        ? (quiz.statesOfMatterScoreBefore / STATES_OF_MATTER_QUESTION_COUNT) * 100
-        : null,
-      typeof quiz.penguinRunScoreBefore === "number" && quiz.penguinRunScoreBefore >= 0
-        ? (quiz.penguinRunScoreBefore / PENGUIN_RUN_QUESTION_COUNT) * 100
-        : null,
-    ];
-
-    return normalizedScores.filter((score): score is number => typeof score === "number");
-  });
-
-  if (scores.length === 0) return 0;
-  return scores.reduce((sum, score) => sum + score, 0) / scores.length;
-}
-
-function getAveragePostQuizScore(
-  quizzes: Array<{
-    stateOfMatterScoreAfter?: number;
-    penguinRunScoreAfter?: number;
-  }>,
-) {
-  const scores = quizzes.flatMap((quiz) => {
-    const normalizedScores = [
-      typeof quiz.stateOfMatterScoreAfter === "number" && quiz.stateOfMatterScoreAfter >= 0
-        ? (quiz.stateOfMatterScoreAfter / STATES_OF_MATTER_QUESTION_COUNT) * 100
-        : null,
-      typeof quiz.penguinRunScoreAfter === "number" && quiz.penguinRunScoreAfter >= 0
-        ? (quiz.penguinRunScoreAfter / PENGUIN_RUN_QUESTION_COUNT) * 100
-        : null,
-    ];
-
-    return normalizedScores.filter((score): score is number => typeof score === "number");
-  });
-
-  if (scores.length === 0) return 0;
-  return scores.reduce((sum, score) => sum + score, 0) / scores.length;
-}
-
-function buildQuizActivities(quiz: {
-  _id: { toString(): string } | string;
-  studentDisplayName?: string | null;
-  updatedAt?: Date;
-  statesOfMatterScoreBefore?: number;
-  stateOfMatterScoreAfter?: number;
-  penguinRunScoreBefore?: number;
-  penguinRunScoreAfter?: number;
-}) {
-  if (!quiz.updatedAt) return [];
-
-  const quizResults = [
-    typeof quiz.stateOfMatterScoreAfter === "number" && quiz.stateOfMatterScoreAfter >= 0
-      ? {
-          label: "States of Matter post-quiz",
-          score: (quiz.stateOfMatterScoreAfter / STATES_OF_MATTER_QUESTION_COUNT) * 100,
-          key: "states-post",
-        }
-      : null,
-    typeof quiz.penguinRunScoreAfter === "number" && quiz.penguinRunScoreAfter >= 0
-      ? {
-          label: "Penguin Run post-quiz",
-          score: (quiz.penguinRunScoreAfter / PENGUIN_RUN_QUESTION_COUNT) * 100,
-          key: "penguin-post",
-        }
-      : null,
-    typeof quiz.statesOfMatterScoreBefore === "number" && quiz.statesOfMatterScoreBefore >= 0
-      ? {
-          label: "States of Matter pre-quiz",
-          score: (quiz.statesOfMatterScoreBefore / STATES_OF_MATTER_QUESTION_COUNT) * 100,
-          key: "states-pre",
-        }
-      : null,
-    typeof quiz.penguinRunScoreBefore === "number" && quiz.penguinRunScoreBefore >= 0
-      ? {
-          label: "Penguin Run pre-quiz",
-          score: (quiz.penguinRunScoreBefore / PENGUIN_RUN_QUESTION_COUNT) * 100,
-          key: "penguin-pre",
-        }
-      : null,
-  ].filter((result): result is { label: string; score: number; key: string } => Boolean(result));
-
-  return quizResults.map((result) => ({
-    id: `quiz-${String(quiz._id)}-${result.key}`,
-    description: `${quiz.studentDisplayName || "A student"} completed ${result.label} with ${formatPercent(result.score)}.`,
-    occurredAt: quiz.updatedAt as Date,
-  }));
+function DashboardHeaderActions() {
+  return (
+    <div className={styles.headerActions}>
+      <Link href="/educatorClassHistory" className={styles.secondaryButton}>
+        Class History
+      </Link>
+      <Link href="/educatorCreateClass?fresh=1" className={styles.restartButton}>
+        Start New Class
+      </Link>
+    </div>
+  );
 }
 
 export default async function EducatorDashboardPage() {
@@ -148,6 +57,7 @@ export default async function EducatorDashboardPage() {
       title: string;
       status: "active" | "closed";
       createdAt: Date;
+      rootSessionId?: { toString(): string } | null;
     } | null>();
 
   if (!classroomSession) {
@@ -160,9 +70,7 @@ export default async function EducatorDashboardPage() {
               <h1 className={styles.title}>Dashboard</h1>
               <p className={styles.subtitle}>Create a classroom session to start seeing live student activity.</p>
             </div>
-            <Link href="/educatorCreateClass?fresh=1" className={styles.restartButton}>
-              Start New Class
-            </Link>
+            <DashboardHeaderActions />
           </div>
           <section className={styles.emptyCard}>
             <h2 className={styles.emptyTitle}>No classroom data yet</h2>
@@ -178,32 +86,9 @@ export default async function EducatorDashboardPage() {
   const sessionId = String(classroomSession._id);
 
   const [participants, gameData, quizzes, accessCode] = await Promise.all([
-    ClassroomParticipant.find({ sessionId }).sort({ joinedAt: 1 }).lean<
-      Array<{
-        _id: { toString(): string } | string;
-        displayName: string;
-        joinedAt: Date;
-      }>
-    >(),
-    GameData.find({ classroomSessionId: sessionId }).sort({ lastUpdated: -1 }).lean<
-      Array<{
-        _id: { toString(): string } | string;
-        gameId: string;
-        lastUpdated: Date;
-        studentDisplayName?: string | null;
-      }>
-    >(),
-    Quiz.find({ classroomSessionId: sessionId }).sort({ updatedAt: -1 }).lean<
-      Array<{
-        _id: { toString(): string } | string;
-        updatedAt?: Date;
-        studentDisplayName?: string | null;
-        statesOfMatterScoreBefore?: number;
-        stateOfMatterScoreAfter?: number;
-        penguinRunScoreBefore?: number;
-        penguinRunScoreAfter?: number;
-      }>
-    >(),
+    ClassroomParticipant.find({ sessionId }).sort({ joinedAt: 1 }).lean<ClassroomParticipantRecord[]>(),
+    GameData.find({ classroomSessionId: sessionId }).sort({ lastUpdated: -1 }).lean<ClassroomGameRecord[]>(),
+    Quiz.find({ classroomSessionId: sessionId }).sort({ updatedAt: -1 }).lean<ClassroomQuizRecord[]>(),
     StudentAccessCode.findOne({ sessionId, isActive: true }).lean<{
       code: string;
     } | null>(),
@@ -216,21 +101,12 @@ export default async function EducatorDashboardPage() {
     { label: "Games Played", value: String(gameData.length) },
   ];
 
-  const activityItems: ActivityItem[] = [
-    ...participants.map((participant) => ({
-      id: `participant-${String(participant._id)}`,
-      description: `${participant.displayName} joined ${classroomSession.title}.`,
-      occurredAt: participant.joinedAt,
-    })),
-    ...gameData.map((game) => ({
-      id: `game-${String(game._id)}`,
-      description: `${game.studentDisplayName || "A student"} played ${game.gameId === "statesOfMatterGame" ? "States of Matter" : "Penguin Run"}.`,
-      occurredAt: game.lastUpdated,
-    })),
-    ...quizzes.flatMap((quiz) => buildQuizActivities(quiz)),
-  ]
-    .sort((a, b) => b.occurredAt.getTime() - a.occurredAt.getTime())
-    .slice(0, 8);
+  const activityItems = buildClassroomActivity({
+    classTitle: classroomSession.title,
+    participants,
+    gameData,
+    quizzes,
+  }).slice(0, ACTIVITY_LIMIT);
 
   return (
     <main className={styles.shell}>
@@ -244,9 +120,7 @@ export default async function EducatorDashboardPage() {
               {classroomSession.status === "active" ? "live" : "most recent"} activity for {classroomSession.title}.
             </p>
           </div>
-          <Link href="/educatorCreateClass?fresh=1" className={styles.restartButton}>
-            Start New Class
-          </Link>
+          <DashboardHeaderActions />
         </div>
 
         {accessCode ? (
@@ -268,7 +142,12 @@ export default async function EducatorDashboardPage() {
         </div>
 
         <section className={styles.activityCard}>
-          <h2 className={styles.activityTitle}>Recent Student Activity</h2>
+          <div className={styles.activityHeader}>
+            <h2 className={styles.activityTitle}>Recent Student Activity</h2>
+            <Link href={`/educatorClassHistory/${getClassId(classroomSession)}`} className={styles.activityLink}>
+              View full class record
+            </Link>
+          </div>
 
           {activityItems.length ? (
             <div className={styles.activityList}>

--- a/src/database/classroomSessionSchema.ts
+++ b/src/database/classroomSessionSchema.ts
@@ -14,6 +14,12 @@ const ClassroomSessionSchema = new Schema(
     createdAt: { type: Date, default: Date.now },
     expiresAt: { type: Date, required: true, index: true },
     closedAt: { type: Date, default: null },
+    // A reopened class is a new session linked back to the one it continues, so historical
+    // participants, game saves, and quiz results are never rewritten or re-attributed.
+    continuedFromId: { type: Schema.Types.ObjectId, ref: "ClassroomSession", default: null, index: true },
+    // Denormalized head of the continuation chain. Null on an original session, so the class a
+    // session belongs to is always `rootSessionId ?? _id`.
+    rootSessionId: { type: Schema.Types.ObjectId, ref: "ClassroomSession", default: null, index: true },
   },
   {
     versionKey: false,
@@ -22,6 +28,7 @@ const ClassroomSessionSchema = new Schema(
 
 ClassroomSessionSchema.index({ teacherId: 1, status: 1, createdAt: -1 });
 ClassroomSessionSchema.index({ status: 1, expiresAt: 1 });
+ClassroomSessionSchema.index({ teacherId: 1, rootSessionId: 1, createdAt: 1 });
 
 // Kept separate from the existing analytics Session model to avoid breaking current routes.
 export default mongoose.models.ClassroomSession ||

--- a/src/database/classroomSessionSchema.ts
+++ b/src/database/classroomSessionSchema.ts
@@ -44,14 +44,19 @@ ClassroomSessionSchema.index(
 );
 
 // Kept separate from the existing analytics Session model to avoid breaking current routes.
+const existingModel = mongoose.models.ClassroomSession;
 const ClassroomSession =
-  mongoose.models.ClassroomSession || mongoose.model("ClassroomSession", ClassroomSessionSchema, "classroomSessions");
+  existingModel || mongoose.model("ClassroomSession", ClassroomSessionSchema, "classroomSessions");
 
 // The "one live continuation per class" guarantee rests entirely on the unique partial index above,
 // and index builds happen in the background. A failure would otherwise remove that guarantee with
 // nothing said, so surface it rather than degrading silently.
-ClassroomSession.on("index", (error: unknown) => {
-  if (error) console.error("ClassroomSession index build failed:", error);
-});
+// Attached only when the model is first created: the model survives dev-server hot reloads, so
+// re-registering on every module evaluation would accumulate listeners.
+if (!existingModel) {
+  ClassroomSession.on("index", (error: unknown) => {
+    if (error) console.error("ClassroomSession index build failed:", error);
+  });
+}
 
 export default ClassroomSession;

--- a/src/database/classroomSessionSchema.ts
+++ b/src/database/classroomSessionSchema.ts
@@ -19,7 +19,7 @@ const ClassroomSessionSchema = new Schema(
     continuedFromId: { type: Schema.Types.ObjectId, ref: "ClassroomSession", default: null, index: true },
     // Denormalized head of the continuation chain. Null on an original session, so the class a
     // session belongs to is always `rootSessionId ?? _id`.
-    rootSessionId: { type: Schema.Types.ObjectId, ref: "ClassroomSession", default: null, index: true },
+    rootSessionId: { type: Schema.Types.ObjectId, ref: "ClassroomSession", default: null },
   },
   {
     versionKey: false,
@@ -29,6 +29,19 @@ const ClassroomSessionSchema = new Schema(
 ClassroomSessionSchema.index({ teacherId: 1, status: 1, createdAt: -1 });
 ClassroomSessionSchema.index({ status: 1, expiresAt: 1 });
 ClassroomSessionSchema.index({ teacherId: 1, rootSessionId: 1, createdAt: 1 });
+// Serves chain reads that are not scoped to one teacher, such as an admin opening a class.
+ClassroomSessionSchema.index({ rootSessionId: 1, createdAt: 1 });
+// At most one live continuation per class, so two concurrent reopens cannot leave a class with two
+// active sessions and two working access codes. `$type` scopes this to continuations: original
+// sessions store a null rootSessionId and are unaffected, so the index is safe to build on
+// existing data.
+ClassroomSessionSchema.index(
+  { rootSessionId: 1 },
+  {
+    unique: true,
+    partialFilterExpression: { rootSessionId: { $type: "objectId" }, status: "active" },
+  },
+);
 
 // Kept separate from the existing analytics Session model to avoid breaking current routes.
 export default mongoose.models.ClassroomSession ||

--- a/src/database/classroomSessionSchema.ts
+++ b/src/database/classroomSessionSchema.ts
@@ -44,5 +44,14 @@ ClassroomSessionSchema.index(
 );
 
 // Kept separate from the existing analytics Session model to avoid breaking current routes.
-export default mongoose.models.ClassroomSession ||
-  mongoose.model("ClassroomSession", ClassroomSessionSchema, "classroomSessions");
+const ClassroomSession =
+  mongoose.models.ClassroomSession || mongoose.model("ClassroomSession", ClassroomSessionSchema, "classroomSessions");
+
+// The "one live continuation per class" guarantee rests entirely on the unique partial index above,
+// and index builds happen in the background. A failure would otherwise remove that guarantee with
+// nothing said, so surface it rather than degrading silently.
+ClassroomSession.on("index", (error: unknown) => {
+  if (error) console.error("ClassroomSession index build failed:", error);
+});
+
+export default ClassroomSession;

--- a/src/lib/quizScoring.ts
+++ b/src/lib/quizScoring.ts
@@ -1,0 +1,97 @@
+import quizData from "@/data/quiz.json";
+
+const typedQuizData = quizData as {
+  penguinRunQuiz?: unknown[];
+  statesOfMatterQuiz?: unknown[];
+};
+
+export const PENGUIN_RUN_QUESTION_COUNT = typedQuizData.penguinRunQuiz?.length || 1;
+export const STATES_OF_MATTER_QUESTION_COUNT = typedQuizData.statesOfMatterQuiz?.length || 1;
+
+export type QuizScoreRecord = {
+  statesOfMatterScoreBefore?: number;
+  stateOfMatterScoreAfter?: number;
+  penguinRunScoreBefore?: number;
+  penguinRunScoreAfter?: number;
+};
+
+export type QuizResultBreakdown = {
+  key: string;
+  label: string;
+  game: "statesOfMatter" | "penguinRun";
+  phase: "pre" | "post";
+  score: number;
+};
+
+// Unattempted quizzes are stored as -1 rather than null, so anything negative is "no result yet".
+export function normalizeQuizScore(score: unknown, questionCount: number): number | null {
+  if (typeof score !== "number" || score < 0) return null;
+  return (score / questionCount) * 100;
+}
+
+export function formatPercent(value: number) {
+  return `${Math.round(value)}%`;
+}
+
+export function averagePercent(values: number[]) {
+  if (values.length === 0) return 0;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+export function getPreQuizPercentages(quiz: QuizScoreRecord) {
+  return [
+    normalizeQuizScore(quiz.statesOfMatterScoreBefore, STATES_OF_MATTER_QUESTION_COUNT),
+    normalizeQuizScore(quiz.penguinRunScoreBefore, PENGUIN_RUN_QUESTION_COUNT),
+  ].filter((score): score is number => score !== null);
+}
+
+export function getPostQuizPercentages(quiz: QuizScoreRecord) {
+  return [
+    normalizeQuizScore(quiz.stateOfMatterScoreAfter, STATES_OF_MATTER_QUESTION_COUNT),
+    normalizeQuizScore(quiz.penguinRunScoreAfter, PENGUIN_RUN_QUESTION_COUNT),
+  ].filter((score): score is number => score !== null);
+}
+
+export function getAveragePreQuizScore(quizzes: QuizScoreRecord[]) {
+  return averagePercent(quizzes.flatMap(getPreQuizPercentages));
+}
+
+export function getAveragePostQuizScore(quizzes: QuizScoreRecord[]) {
+  return averagePercent(quizzes.flatMap(getPostQuizPercentages));
+}
+
+// Ordered post-quiz first so recent-activity feeds surface the outcome before the baseline.
+export function getQuizResultBreakdown(quiz: QuizScoreRecord): QuizResultBreakdown[] {
+  const candidates: Array<Omit<QuizResultBreakdown, "score"> & { score: number | null }> = [
+    {
+      key: "states-post",
+      label: "States of Matter post-quiz",
+      game: "statesOfMatter",
+      phase: "post",
+      score: normalizeQuizScore(quiz.stateOfMatterScoreAfter, STATES_OF_MATTER_QUESTION_COUNT),
+    },
+    {
+      key: "penguin-post",
+      label: "Penguin Run post-quiz",
+      game: "penguinRun",
+      phase: "post",
+      score: normalizeQuizScore(quiz.penguinRunScoreAfter, PENGUIN_RUN_QUESTION_COUNT),
+    },
+    {
+      key: "states-pre",
+      label: "States of Matter pre-quiz",
+      game: "statesOfMatter",
+      phase: "pre",
+      score: normalizeQuizScore(quiz.statesOfMatterScoreBefore, STATES_OF_MATTER_QUESTION_COUNT),
+    },
+    {
+      key: "penguin-pre",
+      label: "Penguin Run pre-quiz",
+      game: "penguinRun",
+      phase: "pre",
+      score: normalizeQuizScore(quiz.penguinRunScoreBefore, PENGUIN_RUN_QUESTION_COUNT),
+    },
+  ];
+
+  return candidates.filter((result): result is QuizResultBreakdown => result.score !== null);
+}

--- a/src/lib/quizScoring.ts
+++ b/src/lib/quizScoring.ts
@@ -24,8 +24,10 @@ export type QuizResultBreakdown = {
 };
 
 // Unattempted quizzes are stored as -1 rather than null, so anything negative is "no result yet".
+// NaN has to be rejected explicitly: `NaN < 0` is false, so a bare comparison would let it through
+// and render as "NaN%", and one NaN poisons every average it is included in.
 export function normalizeQuizScore(score: unknown, questionCount: number): number | null {
-  if (typeof score !== "number" || score < 0) return null;
+  if (typeof score !== "number" || !Number.isFinite(score) || score < 0) return null;
   return (score / questionCount) * 100;
 }
 

--- a/src/lib/server/classroomClasses.test.ts
+++ b/src/lib/server/classroomClasses.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   sessionFindOne: vi.fn(),
   sessionFind: vi.fn(),
   sessionUpdateOne: vi.fn(),
+  sessionDeleteOne: vi.fn(),
   sessionCreate: vi.fn(),
   codeFindOne: vi.fn(),
   codeUpdateMany: vi.fn(),
@@ -17,6 +18,7 @@ vi.mock("@/database/classroomSessionSchema", () => ({
     findOne: mocks.sessionFindOne,
     find: mocks.sessionFind,
     updateOne: mocks.sessionUpdateOne,
+    deleteOne: mocks.sessionDeleteOne,
     create: mocks.sessionCreate,
   },
 }));
@@ -67,6 +69,7 @@ function stubChain(rootRecord: unknown, chain: unknown[]) {
 describe("reopenClassroomClass", () => {
   beforeEach(() => {
     mocks.sessionUpdateOne.mockResolvedValue({});
+    mocks.sessionDeleteOne.mockResolvedValue({});
     mocks.codeUpdateMany.mockResolvedValue({});
     mocks.closeActiveClassroomSessions.mockResolvedValue([]);
     mocks.issueAccessCode.mockResolvedValue("NEWCODE-9Z8");
@@ -174,7 +177,7 @@ describe("reopenClassroomClass", () => {
     expect(mocks.closeActiveClassroomSessions).not.toHaveBeenCalled();
   });
 
-  it("rolls the continuation back when no access code can be issued", async () => {
+  it("deletes the continuation when no access code can be issued", async () => {
     stubChain(EXPIRED_ROOT, [EXPIRED_ROOT]);
     mocks.issueAccessCode.mockRejectedValue(new Error("no code available"));
 
@@ -182,10 +185,38 @@ describe("reopenClassroomClass", () => {
       "no code available",
     );
 
-    // Otherwise the class would sit active-but-unjoinable, and reopening it again would no-op.
-    expect(mocks.sessionUpdateOne).toHaveBeenCalledWith(
-      { _id: NEW_SESSION_ID },
-      { $set: { status: "closed", closedAt: NOW } },
+    // Closing it instead would leave a phantom newest session that hijacks the class's title,
+    // expiry, and reopen count, and renders in the timeline as a continuation nobody ever joined.
+    expect(mocks.sessionDeleteOne).toHaveBeenCalledWith({ _id: NEW_SESSION_ID });
+    expect(mocks.sessionUpdateOne).not.toHaveBeenCalledWith({ _id: NEW_SESSION_ID }, expect.anything());
+  });
+
+  it("yields to a concurrent reopen instead of creating a second live session", async () => {
+    stubChain(EXPIRED_ROOT, [EXPIRED_ROOT]);
+    // The unique partial index rejects the second continuation of the same chain.
+    mocks.sessionCreate.mockRejectedValue(Object.assign(new Error("E11000 duplicate key"), { code: 11000 }));
+    mocks.sessionFindOne.mockReturnValueOnce(leanOf(EXPIRED_ROOT)).mockReturnValueOnce({
+      sort: () => leanOf({ ...EXPIRED_ROOT, _id: CONTINUATION_ID, expiresAt: new Date(NOW.getTime() + 60_000) }),
+    });
+    mocks.codeFindOne.mockReturnValue(leanOf({ code: "WINNER-1A2" }));
+
+    const result = await reopenClassroomClass({ classId: String(ROOT_ID), teacherId: TEACHER_ID, now: NOW });
+
+    expect(result).toMatchObject({
+      ok: true,
+      reopened: false,
+      sessionId: String(CONTINUATION_ID),
+      accessCode: "WINNER-1A2",
+    });
+    expect(mocks.issueAccessCode).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a create failure that is not a uniqueness collision", async () => {
+    stubChain(EXPIRED_ROOT, [EXPIRED_ROOT]);
+    mocks.sessionCreate.mockRejectedValue(new Error("connection lost"));
+
+    await expect(reopenClassroomClass({ classId: String(ROOT_ID), teacherId: TEACHER_ID, now: NOW })).rejects.toThrow(
+      "connection lost",
     );
   });
 

--- a/src/lib/server/classroomClasses.test.ts
+++ b/src/lib/server/classroomClasses.test.ts
@@ -56,8 +56,9 @@ function leanOf(value: unknown) {
   return { lean: () => Promise.resolve(value) };
 }
 
+/** Mirrors `find().select().sort().lean()` on the chain query. */
 function sortLeanOf(value: unknown) {
-  return { sort: () => ({ lean: () => Promise.resolve(value) }) };
+  return { select: () => ({ sort: () => ({ lean: () => Promise.resolve(value) }) }) };
 }
 
 /** Answers the root lookup with `rootRecord` and the chain query with `chain`. */

--- a/src/lib/server/classroomClasses.test.ts
+++ b/src/lib/server/classroomClasses.test.ts
@@ -139,15 +139,29 @@ describe("reopenClassroomClass", () => {
     );
   });
 
-  it("closes any other class the educator still has open, sparing this one", async () => {
+  it("closes any other class the educator still has open, sparing this whole chain", async () => {
     stubChain(EXPIRED_ROOT, [EXPIRED_ROOT]);
 
     await reopenClassroomClass({ classId: String(ROOT_ID), teacherId: TEACHER_ID, now: NOW });
 
+    // Excluded by chain root, not by a list of session ids read earlier: a concurrent reopen can
+    // append a continuation in between, and a stale list would close it as an unrelated class.
     expect(mocks.closeActiveClassroomSessions).toHaveBeenCalledWith(TEACHER_ID, {
-      exceptSessionIds: [ROOT_ID],
+      exceptChainRootId: String(ROOT_ID),
       now: NOW,
     });
+  });
+
+  it("closes the educator's other class only after the reopen has succeeded", async () => {
+    stubChain(EXPIRED_ROOT, [EXPIRED_ROOT]);
+    mocks.issueAccessCode.mockRejectedValue(new Error("no code available"));
+
+    await expect(reopenClassroomClass({ classId: String(ROOT_ID), teacherId: TEACHER_ID, now: NOW })).rejects.toThrow(
+      "no code available",
+    );
+
+    // Otherwise a failed reopen would leave another class's students locked out for nothing.
+    expect(mocks.closeActiveClassroomSessions).not.toHaveBeenCalled();
   });
 
   it("closes an expired session against its own expiry rather than the reopen time", async () => {

--- a/src/lib/server/classroomClasses.test.ts
+++ b/src/lib/server/classroomClasses.test.ts
@@ -34,7 +34,7 @@ vi.mock("@/lib/server/educatorClassroom", () => ({
   issueAccessCode: mocks.issueAccessCode,
 }));
 
-import { reopenClassroomClass } from "@/lib/server/classroomClasses";
+import { parseClassPageLimit, parseClassPageOffset, reopenClassroomClass } from "@/lib/server/classroomClasses";
 
 const NOW = new Date("2026-08-22T18:00:00.000Z");
 const TEACHER_ID = new mongoose.Types.ObjectId();
@@ -253,5 +253,26 @@ describe("reopenClassroomClass", () => {
     expect(mocks.sessionCreate).toHaveBeenCalledWith(
       expect.objectContaining({ continuedFromId: CONTINUATION_ID, rootSessionId: ROOT_ID }),
     );
+  });
+});
+
+describe("class page parameters", () => {
+  it("falls back to the default page size for missing or nonsense limits", () => {
+    expect(parseClassPageLimit(undefined)).toBe(25);
+    expect(parseClassPageLimit("0")).toBe(25);
+    expect(parseClassPageLimit("-5")).toBe(25);
+    expect(parseClassPageLimit("banana")).toBe(25);
+  });
+
+  it("caps the page size rather than honouring an arbitrary one", () => {
+    expect(parseClassPageLimit("50")).toBe(50);
+    expect(parseClassPageLimit("100000")).toBe(200);
+  });
+
+  it("treats a missing or negative offset as the first page", () => {
+    expect(parseClassPageOffset(undefined)).toBe(0);
+    expect(parseClassPageOffset("-3")).toBe(0);
+    expect(parseClassPageOffset("banana")).toBe(0);
+    expect(parseClassPageOffset("40")).toBe(40);
   });
 });

--- a/src/lib/server/classroomClasses.test.ts
+++ b/src/lib/server/classroomClasses.test.ts
@@ -1,0 +1,211 @@
+import mongoose from "mongoose";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  sessionFindOne: vi.fn(),
+  sessionFind: vi.fn(),
+  sessionUpdateOne: vi.fn(),
+  sessionCreate: vi.fn(),
+  codeFindOne: vi.fn(),
+  codeUpdateMany: vi.fn(),
+  closeActiveClassroomSessions: vi.fn(),
+  issueAccessCode: vi.fn(),
+}));
+
+vi.mock("@/database/classroomSessionSchema", () => ({
+  default: {
+    findOne: mocks.sessionFindOne,
+    find: mocks.sessionFind,
+    updateOne: mocks.sessionUpdateOne,
+    create: mocks.sessionCreate,
+  },
+}));
+vi.mock("@/database/studentAccessCodeSchema", () => ({
+  default: { findOne: mocks.codeFindOne, updateMany: mocks.codeUpdateMany, find: vi.fn() },
+}));
+vi.mock("@/database/classroomParticipantSchema", () => ({ default: { find: vi.fn() } }));
+vi.mock("@/database/gameDataSchema", () => ({ default: { find: vi.fn() } }));
+vi.mock("@/database/quizSchema", () => ({ default: { find: vi.fn() } }));
+vi.mock("@/lib/server/educatorClassroom", () => ({
+  SESSION_DURATION_MS: 8 * 60 * 60 * 1000,
+  closeActiveClassroomSessions: mocks.closeActiveClassroomSessions,
+  issueAccessCode: mocks.issueAccessCode,
+}));
+
+import { reopenClassroomClass } from "@/lib/server/classroomClasses";
+
+const NOW = new Date("2026-08-22T18:00:00.000Z");
+const TEACHER_ID = new mongoose.Types.ObjectId();
+const ROOT_ID = new mongoose.Types.ObjectId();
+const CONTINUATION_ID = new mongoose.Types.ObjectId();
+const NEW_SESSION_ID = new mongoose.Types.ObjectId();
+
+const EXPIRED_ROOT = {
+  _id: ROOT_ID,
+  title: "4th Grade Science",
+  status: "active" as const,
+  createdAt: new Date("2026-08-20T09:00:00.000Z"),
+  expiresAt: new Date("2026-08-20T17:00:00.000Z"),
+  closedAt: null,
+  rootSessionId: null,
+};
+
+function leanOf(value: unknown) {
+  return { lean: () => Promise.resolve(value) };
+}
+
+function sortLeanOf(value: unknown) {
+  return { sort: () => ({ lean: () => Promise.resolve(value) }) };
+}
+
+/** Answers the root lookup with `rootRecord` and the chain query with `chain`. */
+function stubChain(rootRecord: unknown, chain: unknown[]) {
+  mocks.sessionFindOne.mockReturnValue(leanOf(rootRecord));
+  mocks.sessionFind.mockReturnValue(sortLeanOf(chain));
+}
+
+describe("reopenClassroomClass", () => {
+  beforeEach(() => {
+    mocks.sessionUpdateOne.mockResolvedValue({});
+    mocks.codeUpdateMany.mockResolvedValue({});
+    mocks.closeActiveClassroomSessions.mockResolvedValue([]);
+    mocks.issueAccessCode.mockResolvedValue("NEWCODE-9Z8");
+    mocks.sessionCreate.mockResolvedValue({ _id: NEW_SESSION_ID });
+  });
+
+  it("rejects an id that is not a classroom session id", async () => {
+    const result = await reopenClassroomClass({ classId: "not-an-object-id", teacherId: TEACHER_ID, now: NOW });
+
+    expect(result).toEqual({ ok: false, reason: "invalid" });
+    expect(mocks.sessionCreate).not.toHaveBeenCalled();
+  });
+
+  it("refuses to reopen a class that does not belong to the educator", async () => {
+    // The teacher-scoped lookup finds nothing, which is how another educator's class presents.
+    stubChain(null, []);
+
+    const result = await reopenClassroomClass({
+      classId: String(ROOT_ID),
+      teacherId: TEACHER_ID,
+      now: NOW,
+    });
+
+    expect(result).toEqual({ ok: false, reason: "not_found" });
+    expect(mocks.sessionFindOne).toHaveBeenCalledWith(expect.objectContaining({ teacherId: TEACHER_ID }));
+    expect(mocks.sessionCreate).not.toHaveBeenCalled();
+    expect(mocks.closeActiveClassroomSessions).not.toHaveBeenCalled();
+  });
+
+  it("appends a linked continuation and issues a fresh code when reopening an expired class", async () => {
+    stubChain(EXPIRED_ROOT, [EXPIRED_ROOT]);
+
+    const result = await reopenClassroomClass({ classId: String(ROOT_ID), teacherId: TEACHER_ID, now: NOW });
+
+    expect(result).toMatchObject({
+      ok: true,
+      reopened: true,
+      classId: String(ROOT_ID),
+      sessionId: String(NEW_SESSION_ID),
+      accessCode: "NEWCODE-9Z8",
+    });
+
+    // The continuation points back at the session it continues and at the class root.
+    expect(mocks.sessionCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teacherId: TEACHER_ID,
+        title: "4th Grade Science",
+        status: "active",
+        continuedFromId: ROOT_ID,
+        rootSessionId: ROOT_ID,
+        closedAt: null,
+      }),
+    );
+    expect(mocks.sessionCreate.mock.calls[0][0].expiresAt).toEqual(new Date("2026-08-23T02:00:00.000Z"));
+    expect(mocks.issueAccessCode).toHaveBeenCalledWith(NEW_SESSION_ID);
+  });
+
+  it("retires every code the class ever issued so a stale code cannot rejoin", async () => {
+    const continuation = { ...EXPIRED_ROOT, _id: CONTINUATION_ID, rootSessionId: ROOT_ID };
+    stubChain(EXPIRED_ROOT, [EXPIRED_ROOT, continuation]);
+
+    await reopenClassroomClass({ classId: String(ROOT_ID), teacherId: TEACHER_ID, now: NOW });
+
+    expect(mocks.codeUpdateMany).toHaveBeenCalledWith(
+      { sessionId: { $in: [ROOT_ID, CONTINUATION_ID] }, isActive: true },
+      { $set: { isActive: false } },
+    );
+  });
+
+  it("closes any other class the educator still has open, sparing this one", async () => {
+    stubChain(EXPIRED_ROOT, [EXPIRED_ROOT]);
+
+    await reopenClassroomClass({ classId: String(ROOT_ID), teacherId: TEACHER_ID, now: NOW });
+
+    expect(mocks.closeActiveClassroomSessions).toHaveBeenCalledWith(TEACHER_ID, {
+      exceptSessionIds: [ROOT_ID],
+      now: NOW,
+    });
+  });
+
+  it("closes an expired session against its own expiry rather than the reopen time", async () => {
+    stubChain(EXPIRED_ROOT, [EXPIRED_ROOT]);
+
+    await reopenClassroomClass({ classId: String(ROOT_ID), teacherId: TEACHER_ID, now: NOW });
+
+    expect(mocks.sessionUpdateOne).toHaveBeenCalledWith(
+      { _id: ROOT_ID },
+      { $set: { status: "closed", closedAt: EXPIRED_ROOT.expiresAt } },
+    );
+  });
+
+  it("leaves a live class untouched and hands back the code it already has", async () => {
+    const liveSession = {
+      ...EXPIRED_ROOT,
+      expiresAt: new Date(NOW.getTime() + 60_000),
+    };
+    stubChain(liveSession, [liveSession]);
+    mocks.codeFindOne.mockReturnValue(leanOf({ code: "LIVECODE-1A2" }));
+
+    const result = await reopenClassroomClass({ classId: String(ROOT_ID), teacherId: TEACHER_ID, now: NOW });
+
+    expect(result).toMatchObject({ ok: true, reopened: false, accessCode: "LIVECODE-1A2" });
+    expect(mocks.sessionCreate).not.toHaveBeenCalled();
+    expect(mocks.codeUpdateMany).not.toHaveBeenCalled();
+    expect(mocks.closeActiveClassroomSessions).not.toHaveBeenCalled();
+  });
+
+  it("rolls the continuation back when no access code can be issued", async () => {
+    stubChain(EXPIRED_ROOT, [EXPIRED_ROOT]);
+    mocks.issueAccessCode.mockRejectedValue(new Error("no code available"));
+
+    await expect(reopenClassroomClass({ classId: String(ROOT_ID), teacherId: TEACHER_ID, now: NOW })).rejects.toThrow(
+      "no code available",
+    );
+
+    // Otherwise the class would sit active-but-unjoinable, and reopening it again would no-op.
+    expect(mocks.sessionUpdateOne).toHaveBeenCalledWith(
+      { _id: NEW_SESSION_ID },
+      { $set: { status: "closed", closedAt: NOW } },
+    );
+  });
+
+  it("normalizes a continuation id to the class root before reopening", async () => {
+    const continuation = { ...EXPIRED_ROOT, _id: CONTINUATION_ID, rootSessionId: ROOT_ID };
+    stubChain(continuation, [EXPIRED_ROOT, continuation]);
+
+    const result = await reopenClassroomClass({
+      classId: String(CONTINUATION_ID),
+      teacherId: TEACHER_ID,
+      now: NOW,
+    });
+
+    expect(result).toMatchObject({ ok: true, reopened: true, classId: String(ROOT_ID) });
+    // The chain is re-queried from the root, not from the id the caller happened to hold.
+    expect(mocks.sessionFind).toHaveBeenCalledWith(
+      expect.objectContaining({ $or: [{ _id: ROOT_ID }, { rootSessionId: ROOT_ID }] }),
+    );
+    expect(mocks.sessionCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ continuedFromId: CONTINUATION_ID, rootSessionId: ROOT_ID }),
+    );
+  });
+});

--- a/src/lib/server/classroomClasses.ts
+++ b/src/lib/server/classroomClasses.ts
@@ -31,8 +31,23 @@ import {
 } from "@/lib/server/classroomHistory";
 import { SESSION_DURATION_MS, closeActiveClassroomSessions, issueAccessCode } from "@/lib/server/educatorClassroom";
 
+/**
+ * The summary as it crosses an API boundary. `ClassroomClassSummary` spreads the class it was built
+ * from, which carries the chain's session documents — including `teacherId`, and on the admin path
+ * that means another educator's. `sessionStates` already describes every session, so the raw rows
+ * are replaced by a count.
+ */
+export type ClassroomClassSummaryView = Omit<ClassroomClassSummary, "sessions" | "latestSession"> & {
+  sessionCount: number;
+};
+
+export function toClassroomClassSummaryView(summary: ClassroomClassSummary): ClassroomClassSummaryView {
+  const { sessions, latestSession: _latestSession, ...rest } = summary;
+  return { ...rest, sessionCount: sessions.length };
+}
+
 export type ClassroomClassDetail = {
-  summary: ClassroomClassSummary;
+  summary: ClassroomClassSummaryView;
   roster: ClassroomRosterView[];
   sessionStates: Array<{
     sessionId: string;
@@ -88,6 +103,14 @@ async function loadClassroomRecords(sessions: Array<{ _id: mongoose.Types.Object
 }
 
 export const DEFAULT_CLASS_PAGE_SIZE = 25;
+export const MAX_CLASS_PAGE_SIZE = 200;
+
+/** Shared by the page and the API route so the two cannot drift apart. */
+export function parseClassPageLimit(value: string | null | undefined) {
+  const parsed = Number.parseInt(value ?? "", 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_CLASS_PAGE_SIZE;
+  return Math.min(parsed, MAX_CLASS_PAGE_SIZE);
+}
 
 /**
  * Summaries for an educator's most recent classes.
@@ -169,6 +192,7 @@ async function findChainSessions(classId: string, teacherId: mongoose.Types.Obje
     $or: [{ _id: rootObjectId }, { rootSessionId: rootObjectId }],
     ...(teacherId ? { teacherId } : {}),
   })
+    .select("title status createdAt expiresAt closedAt continuedFromId rootSessionId")
     .sort({ createdAt: 1 })
     .lean<Array<ClassroomSessionRecord & { _id: mongoose.Types.ObjectId }>>();
 
@@ -191,7 +215,7 @@ export async function loadClassDetail(
   const summary = summarizeClassroomClass(classroomClass, { participants, accessCodes, gameData, quizzes });
 
   return {
-    summary,
+    summary: toClassroomClassSummaryView(summary),
     roster: buildClassroomRoster(participants).map(toClassroomRosterView),
     sessionStates: classroomClass.sessions.map((session) => {
       const sessionId = toIdString(session._id) as string;

--- a/src/lib/server/classroomClasses.ts
+++ b/src/lib/server/classroomClasses.ts
@@ -96,23 +96,27 @@ export const DEFAULT_CLASS_PAGE_SIZE = 25;
  * *before* their participants, codes, saves, and quizzes are read. Without that, an educator with a
  * term of history would pull every row they have ever produced on each page view.
  */
+export type TeacherClassSummaryPage = {
+  classes: ClassroomClassSummary[];
+  total: number;
+  hasMore: boolean;
+};
+
 export async function loadTeacherClassSummaries(
   teacherId: mongoose.Types.ObjectId | string,
   now: Date = new Date(),
   limit: number = DEFAULT_CLASS_PAGE_SIZE,
-): Promise<ClassroomClassSummary[]> {
+): Promise<TeacherClassSummaryPage> {
   const allSessions = await ClassroomSession.find({ teacherId })
     .select("title status createdAt expiresAt closedAt continuedFromId rootSessionId")
     .sort({ createdAt: 1 })
     .lean<Array<ClassroomSessionRecord & { _id: mongoose.Types.ObjectId }>>();
 
-  if (allSessions.length === 0) return [];
+  if (allSessions.length === 0) return { classes: [], total: 0, hasMore: false };
 
-  const pagedClassIds = new Set(
-    groupSessionsIntoClasses(allSessions, now)
-      .slice(0, limit)
-      .map((classroomClass) => classroomClass.classId),
-  );
+  const allClasses = groupSessionsIntoClasses(allSessions, now);
+  const pagedClasses = allClasses.slice(0, limit);
+  const pagedClassIds = new Set(pagedClasses.map((classroomClass) => classroomClass.classId));
   const sessions = allSessions.filter((session) => pagedClassIds.has(getClassId(session)));
 
   const [participants, accessCodes, gameData, quizzes] = await loadClassroomRecords(sessions);
@@ -122,14 +126,18 @@ export async function loadTeacherClassSummaries(
   const gameDataByClass = bucketBySessionOwner(gameData, classIdBySessionId);
   const quizzesByClass = bucketBySessionOwner(quizzes, classIdBySessionId);
 
-  return groupSessionsIntoClasses(sessions, now).map((classroomClass) =>
-    summarizeClassroomClass(classroomClass, {
-      participants: participantsByClass.get(classroomClass.classId) ?? [],
-      accessCodes: accessCodesByClass.get(classroomClass.classId) ?? [],
-      gameData: gameDataByClass.get(classroomClass.classId) ?? [],
-      quizzes: quizzesByClass.get(classroomClass.classId) ?? [],
-    }),
-  );
+  return {
+    classes: pagedClasses.map((classroomClass) =>
+      summarizeClassroomClass(classroomClass, {
+        participants: participantsByClass.get(classroomClass.classId) ?? [],
+        accessCodes: accessCodesByClass.get(classroomClass.classId) ?? [],
+        gameData: gameDataByClass.get(classroomClass.classId) ?? [],
+        quizzes: quizzesByClass.get(classroomClass.classId) ?? [],
+      }),
+    ),
+    total: allClasses.length,
+    hasMore: allClasses.length > pagedClasses.length,
+  };
 }
 
 /**
@@ -167,10 +175,13 @@ async function findChainSessions(classId: string, teacherId: mongoose.Types.Obje
   return { rootId, sessions };
 }
 
+export const DEFAULT_ACTIVITY_LIMIT = 12;
+
 export async function loadClassDetail(
   classId: string,
   teacherId: mongoose.Types.ObjectId | string | null,
   now: Date = new Date(),
+  activityLimit: number = DEFAULT_ACTIVITY_LIMIT,
 ): Promise<ClassroomClassDetail | null> {
   const { sessions } = await findChainSessions(classId, teacherId);
   if (sessions.length === 0) return null;
@@ -203,12 +214,14 @@ export async function loadClassDetail(
     }),
     gameData: gameData.map(toClassroomGameView),
     quizzes: quizzes.map(toClassroomQuizView),
+    // The feed is derived from roster, game, and quiz rows that are already in this response, so
+    // serializing all of it would send the same data twice. Only the slice that gets rendered.
     activity: buildClassroomActivity({
       classTitle: classroomClass.title,
       participants,
       gameData,
       quizzes,
-    }),
+    }).slice(0, activityLimit),
   };
 }
 
@@ -277,11 +290,14 @@ export async function reopenClassroomClass(input: {
 
   const chainIds = sessions.map((session) => session._id);
 
-  // Any other class this educator still has open must yield, matching how starting a new class behaves.
-  await closeActiveClassroomSessions(input.teacherId, { exceptSessionIds: chainIds, now });
+  // Order matters. Everything below up to the continuation touches only this class, which is
+  // already closed or expired, so a failure leaves nothing worse off. Closing the educator's *other*
+  // live class is destructive to its students, so it is deferred until this reopen has actually
+  // succeeded.
 
   // An expired session is still stored as "active"; close it against its own expiry so the history
-  // timeline reports when it actually ended rather than when it was reopened.
+  // timeline reports when it actually ended rather than when it was reopened. This also frees the
+  // chain's slot in the unique partial index before the continuation is inserted.
   await Promise.all(
     sessions
       .filter((session) => session.status === "active")
@@ -328,6 +344,11 @@ export async function reopenClassroomClass(input: {
     await ClassroomSession.deleteOne({ _id: continuation._id });
     throw error;
   }
+
+  // The reopen has succeeded, so it is now safe to make the educator's other class yield, matching
+  // how starting a new class behaves. Excluded by chain rather than by the ids read above, so a
+  // continuation created by a concurrent reopen is never mistaken for an unrelated class.
+  await closeActiveClassroomSessions(input.teacherId, { exceptChainRootId: rootId, now });
 
   return {
     ok: true,

--- a/src/lib/server/classroomClasses.ts
+++ b/src/lib/server/classroomClasses.ts
@@ -10,7 +10,9 @@ import {
   ClassroomGameRecord,
   ClassroomParticipantRecord,
   ClassroomQuizRecord,
-  ClassroomRosterEntry,
+  ClassroomGameView,
+  ClassroomQuizView,
+  ClassroomRosterView,
   ClassroomSessionRecord,
   ClassroomSessionState,
   buildClassIdBySessionId,
@@ -22,13 +24,16 @@ import {
   groupSessionsIntoClasses,
   resolveClassroomSessionState,
   summarizeClassroomClass,
+  toClassroomGameView,
+  toClassroomQuizView,
+  toClassroomRosterView,
   toIdString,
 } from "@/lib/server/classroomHistory";
 import { SESSION_DURATION_MS, closeActiveClassroomSessions, issueAccessCode } from "@/lib/server/educatorClassroom";
 
 export type ClassroomClassDetail = {
   summary: ClassroomClassSummary;
-  roster: ClassroomRosterEntry[];
+  roster: ClassroomRosterView[];
   sessionStates: Array<{
     sessionId: string;
     title: string;
@@ -38,8 +43,8 @@ export type ClassroomClassDetail = {
     closedAt: Date | null;
     accessCodes: Array<{ code: string; isActive: boolean; createdAt: Date; lastSeenAt: Date | null }>;
   }>;
-  gameData: ClassroomGameRecord[];
-  quizzes: ClassroomQuizRecord[];
+  gameData: ClassroomGameView[];
+  quizzes: ClassroomQuizView[];
   activity: ReturnType<typeof buildClassroomActivity>;
 };
 
@@ -55,31 +60,60 @@ async function loadClassroomRecords(sessions: Array<{ _id: mongoose.Types.Object
   const objectIds = sessions.map((session) => session._id);
   const sessionIds = toSessionIdStrings(sessions);
 
+  // Every projection below is a whitelist. Quiz documents carry `clerkId`, `quizId`, and full
+  // per-question answers, and GameData carries `userId`/`saveId`; none of that belongs in a history
+  // view, so it is never read rather than being stripped later.
   return Promise.all([
     ClassroomParticipant.find({ sessionId: { $in: objectIds } })
+      .select("sessionId participantKey displayName joinedAt lastSeenAt")
       .sort({ joinedAt: 1 })
       .lean<ClassroomParticipantRecord[]>(),
     StudentAccessCode.find({ sessionId: { $in: objectIds } })
+      .select("sessionId code isActive createdAt lastSeenAt")
       .sort({ createdAt: 1 })
       .lean<ClassroomAccessCodeRecord[]>(),
     GameData.find({ classroomSessionId: { $in: sessionIds } })
+      .select(
+        "classroomSessionId classroomParticipantId gameId lastUpdated studentDisplayName completedLevels completedStageIds",
+      )
       .sort({ lastUpdated: -1 })
       .lean<ClassroomGameRecord[]>(),
     Quiz.find({ classroomSessionId: { $in: sessionIds } })
+      .select(
+        "classroomSessionId classroomParticipantId studentDisplayName completed updatedAt statesOfMatterScoreBefore stateOfMatterScoreAfter penguinRunScoreBefore penguinRunScoreAfter",
+      )
       .sort({ updatedAt: -1 })
       .lean<ClassroomQuizRecord[]>(),
   ]);
 }
 
+export const DEFAULT_CLASS_PAGE_SIZE = 25;
+
+/**
+ * Summaries for an educator's most recent classes.
+ *
+ * Metrics are computed in JS, so the record fan-out is bounded by trimming to a page of classes
+ * *before* their participants, codes, saves, and quizzes are read. Without that, an educator with a
+ * term of history would pull every row they have ever produced on each page view.
+ */
 export async function loadTeacherClassSummaries(
   teacherId: mongoose.Types.ObjectId | string,
   now: Date = new Date(),
+  limit: number = DEFAULT_CLASS_PAGE_SIZE,
 ): Promise<ClassroomClassSummary[]> {
-  const sessions = await ClassroomSession.find({ teacherId })
+  const allSessions = await ClassroomSession.find({ teacherId })
+    .select("title status createdAt expiresAt closedAt continuedFromId rootSessionId")
     .sort({ createdAt: 1 })
     .lean<Array<ClassroomSessionRecord & { _id: mongoose.Types.ObjectId }>>();
 
-  if (sessions.length === 0) return [];
+  if (allSessions.length === 0) return [];
+
+  const pagedClassIds = new Set(
+    groupSessionsIntoClasses(allSessions, now)
+      .slice(0, limit)
+      .map((classroomClass) => classroomClass.classId),
+  );
+  const sessions = allSessions.filter((session) => pagedClassIds.has(getClassId(session)));
 
   const [participants, accessCodes, gameData, quizzes] = await loadClassroomRecords(sessions);
   const classIdBySessionId = buildClassIdBySessionId(sessions);
@@ -147,7 +181,7 @@ export async function loadClassDetail(
 
   return {
     summary,
-    roster: buildClassroomRoster(participants),
+    roster: buildClassroomRoster(participants).map(toClassroomRosterView),
     sessionStates: classroomClass.sessions.map((session) => {
       const sessionId = toIdString(session._id) as string;
       return {
@@ -167,14 +201,50 @@ export async function loadClassDetail(
           })),
       };
     }),
-    gameData,
-    quizzes,
+    gameData: gameData.map(toClassroomGameView),
+    quizzes: quizzes.map(toClassroomQuizView),
     activity: buildClassroomActivity({
       classTitle: classroomClass.title,
       participants,
       gameData,
       quizzes,
     }),
+  };
+}
+
+/**
+ * Describes a chain that is already live, for callers that must not reopen it again — the caller
+ * that found it active, and the loser of a concurrent reopen race.
+ */
+async function describeActiveChain(
+  rootId: string,
+  teacherId: mongoose.Types.ObjectId | string,
+  now: Date,
+  knownSession?: ClassroomSessionRecord & { _id: mongoose.Types.ObjectId },
+): Promise<ReopenClassroomResult> {
+  const activeSession =
+    knownSession ??
+    (await ClassroomSession.findOne({
+      rootSessionId: new mongoose.Types.ObjectId(rootId),
+      teacherId,
+      status: "active",
+    })
+      .sort({ createdAt: -1 })
+      .lean<(ClassroomSessionRecord & { _id: mongoose.Types.ObjectId }) | null>());
+
+  if (!activeSession) return { ok: false, reason: "not_found" };
+
+  const activeCode = await StudentAccessCode.findOne({ sessionId: activeSession._id, isActive: true }).lean<{
+    code: string;
+  } | null>();
+
+  return {
+    ok: true,
+    reopened: false,
+    classId: rootId,
+    sessionId: String(activeSession._id),
+    accessCode: activeCode?.code ?? null,
+    expiresAt: activeSession.expiresAt,
   };
 }
 
@@ -202,18 +272,7 @@ export async function reopenClassroomClass(input: {
   const latestSession = sessions[sessions.length - 1];
 
   if (resolveClassroomSessionState(latestSession, now) === "active") {
-    const activeCode = await StudentAccessCode.findOne({ sessionId: latestSession._id, isActive: true }).lean<{
-      code: string;
-    } | null>();
-
-    return {
-      ok: true,
-      reopened: false,
-      classId: rootId,
-      sessionId: String(latestSession._id),
-      accessCode: activeCode?.code ?? null,
-      expiresAt: latestSession.expiresAt,
-    };
+    return describeActiveChain(rootId, input.teacherId, now, latestSession);
   }
 
   const chainIds = sessions.map((session) => session._id);
@@ -238,24 +297,35 @@ export async function reopenClassroomClass(input: {
   await StudentAccessCode.updateMany({ sessionId: { $in: chainIds }, isActive: true }, { $set: { isActive: false } });
 
   const expiresAt = new Date(now.getTime() + SESSION_DURATION_MS);
-  const continuation = await ClassroomSession.create({
-    teacherId: input.teacherId,
-    title: latestSession.title,
-    status: "active",
-    createdAt: now,
-    expiresAt,
-    closedAt: null,
-    continuedFromId: latestSession._id,
-    rootSessionId: new mongoose.Types.ObjectId(rootId),
-  });
+
+  let continuation: { _id: mongoose.Types.ObjectId };
+  try {
+    continuation = await ClassroomSession.create({
+      teacherId: input.teacherId,
+      title: latestSession.title,
+      status: "active",
+      createdAt: now,
+      expiresAt,
+      closedAt: null,
+      continuedFromId: latestSession._id,
+      rootSessionId: new mongoose.Types.ObjectId(rootId),
+    });
+  } catch (error: any) {
+    // A unique partial index allows only one active continuation per chain. Losing that race means
+    // a concurrent reopen already succeeded, so report its result instead of creating a second live
+    // session with a second working code.
+    if (error?.code !== 11000) throw error;
+    return describeActiveChain(rootId, input.teacherId, now);
+  }
 
   let accessCode: string;
   try {
     accessCode = await issueAccessCode(continuation._id);
   } catch (error) {
-    // An active session with no code cannot be joined and cannot be reopened again, so roll the
-    // continuation back and let the caller retry rather than stranding the class.
-    await ClassroomSession.updateOne({ _id: continuation._id }, { $set: { status: "closed", closedAt: now } });
+    // Delete rather than close. A closed phantom would stay in the chain as its newest session,
+    // taking over the class's title, expiry, and reopen count, and showing up in the timeline as a
+    // continuation that never existed for anyone. Nothing references it yet.
+    await ClassroomSession.deleteOne({ _id: continuation._id });
     throw error;
   }
 

--- a/src/lib/server/classroomClasses.ts
+++ b/src/lib/server/classroomClasses.ts
@@ -112,16 +112,24 @@ export function parseClassPageLimit(value: string | null | undefined) {
   return Math.min(parsed, MAX_CLASS_PAGE_SIZE);
 }
 
+export function parseClassPageOffset(value: string | null | undefined) {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
+
 /**
  * Summaries for an educator's most recent classes.
  *
- * Metrics are computed in JS, so the record fan-out is bounded by trimming to a page of classes
- * *before* their participants, codes, saves, and quizzes are read. Without that, an educator with a
- * term of history would pull every row they have ever produced on each page view.
+ * Metrics are computed in JS, so the *record* fan-out is bounded by selecting a page of classes
+ * before their participants, codes, saves, and quizzes are read — otherwise an educator with a term
+ * of history would pull every row they have ever produced on each page view. The session rows
+ * themselves are still read in full, since grouping them into chains and counting the classes
+ * requires all of them; they are projected, but this remains one scan per teacher per request.
  */
 export type TeacherClassSummaryPage = {
   classes: ClassroomClassSummary[];
   total: number;
+  offset: number;
   hasMore: boolean;
 };
 
@@ -129,16 +137,18 @@ export async function loadTeacherClassSummaries(
   teacherId: mongoose.Types.ObjectId | string,
   now: Date = new Date(),
   limit: number = DEFAULT_CLASS_PAGE_SIZE,
+  offset: number = 0,
 ): Promise<TeacherClassSummaryPage> {
   const allSessions = await ClassroomSession.find({ teacherId })
     .select("title status createdAt expiresAt closedAt continuedFromId rootSessionId")
     .sort({ createdAt: 1 })
     .lean<Array<ClassroomSessionRecord & { _id: mongoose.Types.ObjectId }>>();
 
-  if (allSessions.length === 0) return { classes: [], total: 0, hasMore: false };
+  if (allSessions.length === 0) return { classes: [], total: 0, offset: 0, hasMore: false };
 
   const allClasses = groupSessionsIntoClasses(allSessions, now);
-  const pagedClasses = allClasses.slice(0, limit);
+  const safeOffset = Math.max(0, Math.min(offset, Math.max(0, allClasses.length - 1)));
+  const pagedClasses = allClasses.slice(safeOffset, safeOffset + limit);
   const pagedClassIds = new Set(pagedClasses.map((classroomClass) => classroomClass.classId));
   const sessions = allSessions.filter((session) => pagedClassIds.has(getClassId(session)));
 
@@ -159,7 +169,8 @@ export async function loadTeacherClassSummaries(
       }),
     ),
     total: allClasses.length,
-    hasMore: allClasses.length > pagedClasses.length,
+    offset: safeOffset,
+    hasMore: allClasses.length > safeOffset + pagedClasses.length,
   };
 }
 
@@ -328,7 +339,14 @@ export async function reopenClassroomClass(input: {
       .map((session) =>
         ClassroomSession.updateOne(
           { _id: session._id },
-          { $set: { status: "closed", closedAt: session.closedAt ?? session.expiresAt } },
+          {
+            $set: {
+              status: "closed",
+              // min(expiresAt, now), matching closeActiveClassroomSessions. Taking expiresAt
+              // unconditionally would stamp a future close date on a session that had not expired.
+              closedAt: session.closedAt ?? (session.expiresAt < now ? session.expiresAt : now),
+            },
+          },
         ),
       ),
   );

--- a/src/lib/server/classroomClasses.ts
+++ b/src/lib/server/classroomClasses.ts
@@ -1,0 +1,270 @@
+import mongoose from "mongoose";
+import ClassroomParticipant from "@/database/classroomParticipantSchema";
+import ClassroomSession from "@/database/classroomSessionSchema";
+import GameData from "@/database/gameDataSchema";
+import Quiz from "@/database/quizSchema";
+import StudentAccessCode from "@/database/studentAccessCodeSchema";
+import {
+  ClassroomAccessCodeRecord,
+  ClassroomClassSummary,
+  ClassroomGameRecord,
+  ClassroomParticipantRecord,
+  ClassroomQuizRecord,
+  ClassroomRosterEntry,
+  ClassroomSessionRecord,
+  ClassroomSessionState,
+  buildClassIdBySessionId,
+  buildClassroomActivity,
+  buildClassroomRoster,
+  bucketByParticipantSession,
+  bucketBySessionOwner,
+  getClassId,
+  groupSessionsIntoClasses,
+  resolveClassroomSessionState,
+  summarizeClassroomClass,
+  toIdString,
+} from "@/lib/server/classroomHistory";
+import { SESSION_DURATION_MS, closeActiveClassroomSessions, issueAccessCode } from "@/lib/server/educatorClassroom";
+
+export type ClassroomClassDetail = {
+  summary: ClassroomClassSummary;
+  roster: ClassroomRosterEntry[];
+  sessionStates: Array<{
+    sessionId: string;
+    title: string;
+    state: ClassroomSessionState;
+    createdAt: Date;
+    expiresAt: Date;
+    closedAt: Date | null;
+    accessCodes: Array<{ code: string; isActive: boolean; createdAt: Date; lastSeenAt: Date | null }>;
+  }>;
+  gameData: ClassroomGameRecord[];
+  quizzes: ClassroomQuizRecord[];
+  activity: ReturnType<typeof buildClassroomActivity>;
+};
+
+export type ReopenClassroomResult =
+  | { ok: false; reason: "invalid" | "not_found" }
+  | { ok: true; reopened: boolean; classId: string; sessionId: string; accessCode: string | null; expiresAt: Date };
+
+function toSessionIdStrings(sessions: Array<{ _id: mongoose.Types.ObjectId }>) {
+  return sessions.map((session) => String(session._id));
+}
+
+async function loadClassroomRecords(sessions: Array<{ _id: mongoose.Types.ObjectId }>) {
+  const objectIds = sessions.map((session) => session._id);
+  const sessionIds = toSessionIdStrings(sessions);
+
+  return Promise.all([
+    ClassroomParticipant.find({ sessionId: { $in: objectIds } })
+      .sort({ joinedAt: 1 })
+      .lean<ClassroomParticipantRecord[]>(),
+    StudentAccessCode.find({ sessionId: { $in: objectIds } })
+      .sort({ createdAt: 1 })
+      .lean<ClassroomAccessCodeRecord[]>(),
+    GameData.find({ classroomSessionId: { $in: sessionIds } })
+      .sort({ lastUpdated: -1 })
+      .lean<ClassroomGameRecord[]>(),
+    Quiz.find({ classroomSessionId: { $in: sessionIds } })
+      .sort({ updatedAt: -1 })
+      .lean<ClassroomQuizRecord[]>(),
+  ]);
+}
+
+export async function loadTeacherClassSummaries(
+  teacherId: mongoose.Types.ObjectId | string,
+  now: Date = new Date(),
+): Promise<ClassroomClassSummary[]> {
+  const sessions = await ClassroomSession.find({ teacherId })
+    .sort({ createdAt: 1 })
+    .lean<Array<ClassroomSessionRecord & { _id: mongoose.Types.ObjectId }>>();
+
+  if (sessions.length === 0) return [];
+
+  const [participants, accessCodes, gameData, quizzes] = await loadClassroomRecords(sessions);
+  const classIdBySessionId = buildClassIdBySessionId(sessions);
+  const participantsByClass = bucketByParticipantSession(participants, classIdBySessionId);
+  const accessCodesByClass = bucketByParticipantSession(accessCodes, classIdBySessionId);
+  const gameDataByClass = bucketBySessionOwner(gameData, classIdBySessionId);
+  const quizzesByClass = bucketBySessionOwner(quizzes, classIdBySessionId);
+
+  return groupSessionsIntoClasses(sessions, now).map((classroomClass) =>
+    summarizeClassroomClass(classroomClass, {
+      participants: participantsByClass.get(classroomClass.classId) ?? [],
+      accessCodes: accessCodesByClass.get(classroomClass.classId) ?? [],
+      gameData: gameDataByClass.get(classroomClass.classId) ?? [],
+      quizzes: quizzesByClass.get(classroomClass.classId) ?? [],
+    }),
+  );
+}
+
+/**
+ * A class is addressed by the id of the session that started it, but educators reach it through
+ * links and saved ids that may point at any session in the chain. Normalizing to the chain root
+ * first keeps every caller consistent regardless of which session id it was handed.
+ */
+export async function resolveClassRootId(classId: string, teacherId: mongoose.Types.ObjectId | string | null) {
+  if (!mongoose.Types.ObjectId.isValid(classId)) return null;
+
+  const session = await ClassroomSession.findOne({
+    _id: new mongoose.Types.ObjectId(classId),
+    ...(teacherId ? { teacherId } : {}),
+  }).lean<{ _id: mongoose.Types.ObjectId; rootSessionId?: mongoose.Types.ObjectId | null } | null>();
+
+  return session ? getClassId(session) : null;
+}
+
+/**
+ * Loads every session in a class's continuation chain. `teacherId` scopes the read to one educator;
+ * pass null only for an actor that has already been authorized to read across educators.
+ */
+async function findChainSessions(classId: string, teacherId: mongoose.Types.ObjectId | string | null) {
+  const rootId = await resolveClassRootId(classId, teacherId);
+  if (!rootId) return { rootId: null, sessions: [] };
+
+  const rootObjectId = new mongoose.Types.ObjectId(rootId);
+  const sessions = await ClassroomSession.find({
+    $or: [{ _id: rootObjectId }, { rootSessionId: rootObjectId }],
+    ...(teacherId ? { teacherId } : {}),
+  })
+    .sort({ createdAt: 1 })
+    .lean<Array<ClassroomSessionRecord & { _id: mongoose.Types.ObjectId }>>();
+
+  return { rootId, sessions };
+}
+
+export async function loadClassDetail(
+  classId: string,
+  teacherId: mongoose.Types.ObjectId | string | null,
+  now: Date = new Date(),
+): Promise<ClassroomClassDetail | null> {
+  const { sessions } = await findChainSessions(classId, teacherId);
+  if (sessions.length === 0) return null;
+
+  const [participants, accessCodes, gameData, quizzes] = await loadClassroomRecords(sessions);
+  const [classroomClass] = groupSessionsIntoClasses(sessions, now);
+  const summary = summarizeClassroomClass(classroomClass, { participants, accessCodes, gameData, quizzes });
+
+  return {
+    summary,
+    roster: buildClassroomRoster(participants),
+    sessionStates: classroomClass.sessions.map((session) => {
+      const sessionId = toIdString(session._id) as string;
+      return {
+        sessionId,
+        title: session.title,
+        state: resolveClassroomSessionState(session, now),
+        createdAt: session.createdAt,
+        expiresAt: session.expiresAt,
+        closedAt: session.closedAt ?? null,
+        accessCodes: accessCodes
+          .filter((accessCode) => toIdString(accessCode.sessionId) === sessionId)
+          .map((accessCode) => ({
+            code: accessCode.code,
+            isActive: accessCode.isActive,
+            createdAt: accessCode.createdAt,
+            lastSeenAt: accessCode.lastSeenAt ?? null,
+          })),
+      };
+    }),
+    gameData,
+    quizzes,
+    activity: buildClassroomActivity({
+      classTitle: classroomClass.title,
+      participants,
+      gameData,
+      quizzes,
+    }),
+  };
+}
+
+/**
+ * Reopens a class by appending a linked continuation session rather than rewriting the closed one.
+ * Prior participants, game saves, and quiz results keep pointing at the sessions that produced
+ * them; only new activity lands on the continuation.
+ */
+export async function reopenClassroomClass(input: {
+  classId: string;
+  teacherId: mongoose.Types.ObjectId | string;
+  now?: Date;
+}): Promise<ReopenClassroomResult> {
+  const now = input.now ?? new Date();
+
+  if (!mongoose.Types.ObjectId.isValid(input.classId)) {
+    return { ok: false, reason: "invalid" };
+  }
+
+  const { rootId, sessions } = await findChainSessions(input.classId, input.teacherId);
+  if (!rootId || sessions.length === 0) {
+    return { ok: false, reason: "not_found" };
+  }
+
+  const latestSession = sessions[sessions.length - 1];
+
+  if (resolveClassroomSessionState(latestSession, now) === "active") {
+    const activeCode = await StudentAccessCode.findOne({ sessionId: latestSession._id, isActive: true }).lean<{
+      code: string;
+    } | null>();
+
+    return {
+      ok: true,
+      reopened: false,
+      classId: rootId,
+      sessionId: String(latestSession._id),
+      accessCode: activeCode?.code ?? null,
+      expiresAt: latestSession.expiresAt,
+    };
+  }
+
+  const chainIds = sessions.map((session) => session._id);
+
+  // Any other class this educator still has open must yield, matching how starting a new class behaves.
+  await closeActiveClassroomSessions(input.teacherId, { exceptSessionIds: chainIds, now });
+
+  // An expired session is still stored as "active"; close it against its own expiry so the history
+  // timeline reports when it actually ended rather than when it was reopened.
+  await Promise.all(
+    sessions
+      .filter((session) => session.status === "active")
+      .map((session) =>
+        ClassroomSession.updateOne(
+          { _id: session._id },
+          { $set: { status: "closed", closedAt: session.closedAt ?? session.expiresAt } },
+        ),
+      ),
+  );
+
+  // Retire every code the chain has ever issued, so a student holding an old one cannot rejoin.
+  await StudentAccessCode.updateMany({ sessionId: { $in: chainIds }, isActive: true }, { $set: { isActive: false } });
+
+  const expiresAt = new Date(now.getTime() + SESSION_DURATION_MS);
+  const continuation = await ClassroomSession.create({
+    teacherId: input.teacherId,
+    title: latestSession.title,
+    status: "active",
+    createdAt: now,
+    expiresAt,
+    closedAt: null,
+    continuedFromId: latestSession._id,
+    rootSessionId: new mongoose.Types.ObjectId(rootId),
+  });
+
+  let accessCode: string;
+  try {
+    accessCode = await issueAccessCode(continuation._id);
+  } catch (error) {
+    // An active session with no code cannot be joined and cannot be reopened again, so roll the
+    // continuation back and let the caller retry rather than stranding the class.
+    await ClassroomSession.updateOne({ _id: continuation._id }, { $set: { status: "closed", closedAt: now } });
+    throw error;
+  }
+
+  return {
+    ok: true,
+    reopened: true,
+    classId: rootId,
+    sessionId: String(continuation._id),
+    accessCode,
+    expiresAt,
+  };
+}

--- a/src/lib/server/classroomClasses.ts
+++ b/src/lib/server/classroomClasses.ts
@@ -147,7 +147,9 @@ export async function loadTeacherClassSummaries(
   if (allSessions.length === 0) return { classes: [], total: 0, offset: 0, hasMore: false };
 
   const allClasses = groupSessionsIntoClasses(allSessions, now);
-  const safeOffset = Math.max(0, Math.min(offset, Math.max(0, allClasses.length - 1)));
+  // Clamped to the end of the list, not to the last class: an offset past the end must return an
+  // empty page rather than silently re-serving the final class under a different offset.
+  const safeOffset = Math.max(0, Math.min(offset, allClasses.length));
   const pagedClasses = allClasses.slice(safeOffset, safeOffset + limit);
   const pagedClassIds = new Set(pagedClasses.map((classroomClass) => classroomClass.classId));
   const sessions = allSessions.filter((session) => pagedClassIds.has(getClassId(session)));
@@ -390,7 +392,15 @@ export async function reopenClassroomClass(input: {
   // The reopen has succeeded, so it is now safe to make the educator's other class yield, matching
   // how starting a new class behaves. Excluded by chain rather than by the ids read above, so a
   // continuation created by a concurrent reopen is never mistaken for an unrelated class.
-  await closeActiveClassroomSessions(input.teacherId, { exceptChainRootId: rootId, now });
+  //
+  // The continuation and its code are already committed at this point, so a failure here must not
+  // be reported as a failed reopen — that would tell the educator nothing happened while handing
+  // their students a live code. The stale open class is recoverable; a wrong answer is not.
+  try {
+    await closeActiveClassroomSessions(input.teacherId, { exceptChainRootId: rootId, now });
+  } catch (error) {
+    console.error("Reopened class but failed to close the educator's other active class:", error);
+  }
 
   return {
     ok: true,

--- a/src/lib/server/classroomHistory.test.ts
+++ b/src/lib/server/classroomHistory.test.ts
@@ -10,6 +10,9 @@ import {
   groupSessionsIntoClasses,
   resolveClassroomSessionState,
   summarizeClassroomClass,
+  toClassroomGameView,
+  toClassroomQuizView,
+  toClassroomRosterView,
 } from "@/lib/server/classroomHistory";
 
 const NOW = new Date("2026-08-22T18:00:00.000Z");
@@ -290,5 +293,78 @@ describe("buildClassroomActivity", () => {
     });
 
     expect(activity).toEqual([]);
+  });
+});
+
+describe("serializable views", () => {
+  it("strips identity and answer detail that must not leave the server", () => {
+    const rosterView = toClassroomRosterView({
+      // participantKey embeds the student's Clerk id verbatim.
+      participantKey: "clerk:user_2abcXYZ",
+      participantIds: ["p1", "p2"],
+      displayName: "Ada",
+      joinedAt: new Date("2026-08-20T09:05:00.000Z"),
+      lastSeenAt: new Date("2026-08-22T15:00:00.000Z"),
+      sessionIds: ["root", "continuation"],
+    });
+
+    expect(rosterView).toEqual({
+      id: "p1",
+      displayName: "Ada",
+      joinedAt: new Date("2026-08-20T09:05:00.000Z"),
+      lastSeenAt: new Date("2026-08-22T15:00:00.000Z"),
+      sessionCount: 2,
+    });
+    expect(JSON.stringify(rosterView)).not.toContain("user_2abcXYZ");
+
+    const quizView = toClassroomQuizView({
+      _id: "q1",
+      studentDisplayName: "Ada",
+      completed: true,
+      updatedAt: new Date("2026-08-20T11:00:00.000Z"),
+      statesOfMatterScoreBefore: 1,
+      stateOfMatterScoreAfter: 3,
+      penguinRunScoreBefore: -1,
+      penguinRunScoreAfter: -1,
+      ...({
+        clerkId: "user_2abcXYZ",
+        quizId: "quiz-user_2abcXYZ",
+        statesOfMatterQuestionResults: [{ selectedAnswer: "Solid" }],
+      } as object),
+    });
+
+    expect(Object.keys(quizView).sort()).toEqual([
+      "completed",
+      "id",
+      "penguinRunScoreAfter",
+      "penguinRunScoreBefore",
+      "stateOfMatterScoreAfter",
+      "statesOfMatterScoreBefore",
+      "studentDisplayName",
+      "updatedAt",
+    ]);
+    expect(JSON.stringify(quizView)).not.toContain("user_2abcXYZ");
+    expect(JSON.stringify(quizView)).not.toContain("Solid");
+
+    const gameView = toClassroomGameView({
+      _id: "g1",
+      gameId: "statesOfMatterGame",
+      lastUpdated: new Date("2026-08-20T10:00:00.000Z"),
+      studentDisplayName: "Ada",
+      completedLevels: [1, 2],
+      completedStageIds: ["a"],
+      ...({ userId: "user_2abcXYZ", saveId: "save-1" } as object),
+    });
+
+    expect(gameView).toEqual({
+      id: "g1",
+      gameId: "statesOfMatterGame",
+      gameLabel: "States of Matter",
+      studentDisplayName: "Ada",
+      completedLevelCount: 2,
+      completedStageCount: 1,
+      lastUpdated: new Date("2026-08-20T10:00:00.000Z"),
+    });
+    expect(JSON.stringify(gameView)).not.toContain("user_2abcXYZ");
   });
 });

--- a/src/lib/server/classroomHistory.test.ts
+++ b/src/lib/server/classroomHistory.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { getPreQuizPercentages, normalizeQuizScore } from "@/lib/quizScoring";
 import {
   ClassroomParticipantRecord,
   ClassroomSessionRecord,
@@ -293,6 +294,22 @@ describe("buildClassroomActivity", () => {
     });
 
     expect(activity).toEqual([]);
+  });
+});
+
+describe("quiz score normalization", () => {
+  it("treats a corrupt score as no result rather than rendering NaN", () => {
+    // `NaN < 0` is false, so a bare negative check would let NaN through into the percentage and
+    // into every average computed from it.
+    expect(normalizeQuizScore(Number.NaN, 3)).toBeNull();
+    expect(normalizeQuizScore(Number.POSITIVE_INFINITY, 3)).toBeNull();
+    expect(normalizeQuizScore(-1, 3)).toBeNull();
+    expect(normalizeQuizScore(0, 3)).toBe(0);
+    expect(normalizeQuizScore(3, 3)).toBe(100);
+  });
+
+  it("keeps a corrupt score out of a class average", () => {
+    expect(getPreQuizPercentages({ statesOfMatterScoreBefore: Number.NaN, penguinRunScoreBefore: 3 })).toEqual([100]);
   });
 });
 

--- a/src/lib/server/classroomHistory.test.ts
+++ b/src/lib/server/classroomHistory.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, it } from "vitest";
+import {
+  ClassroomParticipantRecord,
+  ClassroomSessionRecord,
+  buildClassIdBySessionId,
+  buildClassroomActivity,
+  buildClassroomRoster,
+  bucketBySessionOwner,
+  getClassId,
+  groupSessionsIntoClasses,
+  resolveClassroomSessionState,
+  summarizeClassroomClass,
+} from "@/lib/server/classroomHistory";
+
+const NOW = new Date("2026-08-22T18:00:00.000Z");
+
+function session(overrides: Partial<ClassroomSessionRecord> & { _id: string }): ClassroomSessionRecord {
+  return {
+    title: "4th Grade Science",
+    status: "closed",
+    createdAt: new Date("2026-08-20T09:00:00.000Z"),
+    expiresAt: new Date("2026-08-20T17:00:00.000Z"),
+    closedAt: null,
+    continuedFromId: null,
+    rootSessionId: null,
+    ...overrides,
+  };
+}
+
+function participant(overrides: Partial<ClassroomParticipantRecord> & { _id: string }): ClassroomParticipantRecord {
+  return {
+    sessionId: "root",
+    participantKey: "guest:abc",
+    displayName: "Ada",
+    joinedAt: new Date("2026-08-20T09:05:00.000Z"),
+    lastSeenAt: new Date("2026-08-20T09:30:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("resolveClassroomSessionState", () => {
+  it("separates closed sessions from ones that merely ran out the clock", () => {
+    const stillRunning = { status: "active" as const, expiresAt: new Date(NOW.getTime() + 60_000) };
+    const ranOut = { status: "active" as const, expiresAt: new Date(NOW.getTime() - 60_000) };
+    const endedEarly = { status: "closed" as const, expiresAt: new Date(NOW.getTime() + 60_000) };
+
+    expect(resolveClassroomSessionState(stillRunning, NOW)).toBe("active");
+    expect(resolveClassroomSessionState(ranOut, NOW)).toBe("expired");
+    expect(resolveClassroomSessionState(endedEarly, NOW)).toBe("closed");
+  });
+
+  it("treats the exact expiry instant as expired", () => {
+    expect(resolveClassroomSessionState({ status: "active", expiresAt: NOW }, NOW)).toBe("expired");
+  });
+});
+
+describe("getClassId", () => {
+  it("addresses an original session by its own id and a continuation by its root", () => {
+    expect(getClassId(session({ _id: "root" }))).toBe("root");
+    expect(getClassId(session({ _id: "continuation", rootSessionId: "root" }))).toBe("root");
+  });
+});
+
+describe("groupSessionsIntoClasses", () => {
+  const root = session({ _id: "root", closedAt: new Date("2026-08-20T17:00:00.000Z") });
+  const continuation = session({
+    _id: "continuation",
+    rootSessionId: "root",
+    status: "active",
+    createdAt: new Date("2026-08-22T14:00:00.000Z"),
+    expiresAt: new Date("2026-08-22T22:00:00.000Z"),
+    title: "4th Grade Science",
+  });
+  // Never explicitly closed, but its 8-hour window elapsed.
+  const otherClass = session({
+    _id: "other",
+    title: "Period 2",
+    status: "active",
+    createdAt: new Date("2026-08-21T09:00:00.000Z"),
+    expiresAt: new Date("2026-08-21T17:00:00.000Z"),
+  });
+
+  it("collapses a continuation chain into one class described by its newest session", () => {
+    const [first, second] = groupSessionsIntoClasses([root, otherClass, continuation], NOW);
+
+    expect(first.classId).toBe("root");
+    expect(first.sessions.map((entry) => String(entry._id))).toEqual(["root", "continuation"]);
+    expect(first.state).toBe("active");
+    expect(first.reopenCount).toBe(1);
+    // The class started when its original session opened, not when it was last reopened.
+    expect(first.createdAt).toEqual(root.createdAt);
+    expect(first.expiresAt).toEqual(continuation.expiresAt);
+
+    expect(second.classId).toBe("other");
+    expect(second.reopenCount).toBe(0);
+    expect(second.state).toBe("expired");
+  });
+
+  it("orders classes by most recent session first", () => {
+    expect(groupSessionsIntoClasses([root, otherClass, continuation], NOW).map((entry) => entry.classId)).toEqual([
+      "root",
+      "other",
+    ]);
+  });
+});
+
+describe("buildClassroomRoster", () => {
+  it("keeps a returning student as one roster entry across reopened sessions", () => {
+    const roster = buildClassroomRoster([
+      participant({ _id: "p1", sessionId: "root", participantKey: "guest:abc", displayName: "Ada" }),
+      participant({
+        _id: "p2",
+        sessionId: "continuation",
+        participantKey: "guest:abc",
+        displayName: "Ada L.",
+        joinedAt: new Date("2026-08-22T14:05:00.000Z"),
+        lastSeenAt: new Date("2026-08-22T15:00:00.000Z"),
+      }),
+      participant({
+        _id: "p3",
+        sessionId: "continuation",
+        participantKey: "clerk:user_2",
+        displayName: "Grace",
+        joinedAt: new Date("2026-08-22T14:10:00.000Z"),
+        lastSeenAt: new Date("2026-08-22T14:40:00.000Z"),
+      }),
+    ]);
+
+    expect(roster).toHaveLength(2);
+
+    const [ada, grace] = roster;
+    expect(ada.participantIds).toEqual(["p1", "p2"]);
+    expect(ada.sessionIds).toEqual(["root", "continuation"]);
+    // Earliest join and latest sighting win, and the newest sighting supplies the display name.
+    expect(ada.joinedAt).toEqual(new Date("2026-08-20T09:05:00.000Z"));
+    expect(ada.lastSeenAt).toEqual(new Date("2026-08-22T15:00:00.000Z"));
+    expect(ada.displayName).toBe("Ada L.");
+
+    expect(grace.participantKey).toBe("clerk:user_2");
+    expect(grace.sessionIds).toEqual(["continuation"]);
+  });
+});
+
+describe("summarizeClassroomClass", () => {
+  const classroomClass = groupSessionsIntoClasses(
+    [
+      session({ _id: "root", closedAt: new Date("2026-08-20T17:00:00.000Z") }),
+      session({
+        _id: "continuation",
+        rootSessionId: "root",
+        status: "active",
+        createdAt: new Date("2026-08-22T14:00:00.000Z"),
+        expiresAt: new Date("2026-08-22T22:00:00.000Z"),
+      }),
+    ],
+    NOW,
+  )[0];
+
+  const input = {
+    participants: [
+      participant({ _id: "p1", sessionId: "root", participantKey: "guest:abc" }),
+      participant({
+        _id: "p2",
+        sessionId: "continuation",
+        participantKey: "guest:abc",
+        lastSeenAt: new Date("2026-08-22T15:00:00.000Z"),
+      }),
+    ],
+    accessCodes: [
+      { _id: "c1", sessionId: "root", code: "OLDCODE-1A2", isActive: false, createdAt: NOW, lastSeenAt: null },
+      { _id: "c2", sessionId: "continuation", code: "NEWCODE-9Z8", isActive: true, createdAt: NOW, lastSeenAt: null },
+    ],
+    gameData: [
+      {
+        _id: "g1",
+        classroomSessionId: "root",
+        gameId: "statesOfMatterGame",
+        lastUpdated: new Date("2026-08-20T10:00:00.000Z"),
+      },
+    ],
+    // 3 questions per quiz: 1/3 -> 33.3%, 3/3 -> 100%.
+    quizzes: [
+      {
+        _id: "q1",
+        classroomSessionId: "root",
+        statesOfMatterScoreBefore: 1,
+        stateOfMatterScoreAfter: 3,
+        penguinRunScoreBefore: -1,
+        penguinRunScoreAfter: -1,
+        updatedAt: new Date("2026-08-20T11:00:00.000Z"),
+      },
+    ],
+  };
+
+  it("reports the merged roster count and the code attached to the newest session", () => {
+    const summary = summarizeClassroomClass(classroomClass, input);
+
+    expect(summary.participantCount).toBe(1);
+    expect(summary.gamesPlayed).toBe(1);
+    expect(summary.quizzesRecorded).toBe(1);
+    expect(summary.activeAccessCode).toBe("NEWCODE-9Z8");
+    expect(summary.lastActivityAt).toEqual(new Date("2026-08-22T15:00:00.000Z"));
+    expect(summary.averagePreQuizScore).toBeCloseTo(100 / 3);
+    expect(summary.averagePostQuizScore).toBe(100);
+  });
+
+  it("reports no active code once the newest session is no longer live", () => {
+    const closedClass = groupSessionsIntoClasses([session({ _id: "root" })], NOW)[0];
+    const summary = summarizeClassroomClass(closedClass, {
+      ...input,
+      accessCodes: [{ _id: "c1", sessionId: "root", code: "OLDCODE-1A2", isActive: true, createdAt: NOW }],
+    });
+
+    expect(summary.state).toBe("closed");
+    expect(summary.activeAccessCode).toBeNull();
+  });
+
+  it("distinguishes an unmeasured average from a zero average", () => {
+    const summary = summarizeClassroomClass(classroomClass, { ...input, quizzes: [] });
+
+    expect(summary.averagePreQuizScore).toBeNull();
+    expect(summary.averagePostQuizScore).toBeNull();
+  });
+});
+
+describe("bucketBySessionOwner", () => {
+  it("routes records from every session in a chain to the class that owns them", () => {
+    const sessions = [
+      session({ _id: "root" }),
+      session({ _id: "continuation", rootSessionId: "root" }),
+      session({ _id: "other" }),
+    ];
+    const buckets = bucketBySessionOwner(
+      [
+        { _id: "a", classroomSessionId: "root" },
+        { _id: "b", classroomSessionId: "continuation" },
+        { _id: "c", classroomSessionId: "other" },
+        { _id: "d", classroomSessionId: "unknown-session" },
+        { _id: "e", classroomSessionId: null },
+      ],
+      buildClassIdBySessionId(sessions),
+    );
+
+    expect(buckets.get("root")?.map((entry) => entry._id)).toEqual(["a", "b"]);
+    expect(buckets.get("other")?.map((entry) => entry._id)).toEqual(["c"]);
+    // Records pointing at sessions outside this teacher's classes are dropped, not misfiled.
+    expect(buckets.has("unknown-session")).toBe(false);
+  });
+});
+
+describe("buildClassroomActivity", () => {
+  it("merges joins, game saves, and quiz results newest first", () => {
+    const activity = buildClassroomActivity({
+      classTitle: "4th Grade Science",
+      participants: [participant({ _id: "p1" })],
+      gameData: [
+        {
+          _id: "g1",
+          gameId: "statesOfMatterGame",
+          lastUpdated: new Date("2026-08-20T10:00:00.000Z"),
+          studentDisplayName: "Ada",
+        },
+      ],
+      quizzes: [
+        {
+          _id: "q1",
+          studentDisplayName: "Ada",
+          stateOfMatterScoreAfter: 3,
+          statesOfMatterScoreBefore: -1,
+          penguinRunScoreBefore: -1,
+          penguinRunScoreAfter: -1,
+          updatedAt: new Date("2026-08-20T11:00:00.000Z"),
+        },
+      ],
+    });
+
+    expect(activity.map((item) => item.description)).toEqual([
+      "Ada completed States of Matter post-quiz with 100%.",
+      "Ada played States of Matter.",
+      "Ada joined 4th Grade Science.",
+    ]);
+  });
+
+  it("skips quiz records that have no timestamp to place them on", () => {
+    const activity = buildClassroomActivity({
+      classTitle: "4th Grade Science",
+      participants: [],
+      gameData: [],
+      quizzes: [{ _id: "q1", stateOfMatterScoreAfter: 3 }],
+    });
+
+    expect(activity).toEqual([]);
+  });
+});

--- a/src/lib/server/classroomHistory.ts
+++ b/src/lib/server/classroomHistory.ts
@@ -341,3 +341,72 @@ export function buildClassIdBySessionId(sessions: ClassroomSessionRecord[]) {
 
   return classIdBySessionId;
 }
+
+/**
+ * Serializable projections of classroom records.
+ *
+ * The stored documents carry identity and answer detail that history views never need — Clerk ids
+ * (directly on a quiz, and embedded in a participant's `participantKey`), quiz/save ids, and every
+ * per-question answer. These views are the only shape that should cross an API boundary.
+ */
+export type ClassroomRosterView = {
+  id: string;
+  displayName: string;
+  joinedAt: Date;
+  lastSeenAt: Date;
+  sessionCount: number;
+};
+
+export type ClassroomGameView = {
+  id: string;
+  gameId: string;
+  gameLabel: string;
+  studentDisplayName: string | null;
+  completedLevelCount: number;
+  completedStageCount: number;
+  lastUpdated: Date;
+};
+
+export type ClassroomQuizView = QuizScoreRecord & {
+  id: string;
+  studentDisplayName: string | null;
+  completed: boolean;
+  updatedAt: Date | null;
+};
+
+export function toClassroomRosterView(entry: ClassroomRosterEntry): ClassroomRosterView {
+  return {
+    // The participant id is stable within the class and carries no external identity, unlike the
+    // participantKey it replaces.
+    id: entry.participantIds[0] ?? entry.participantKey,
+    displayName: entry.displayName,
+    joinedAt: entry.joinedAt,
+    lastSeenAt: entry.lastSeenAt,
+    sessionCount: entry.sessionIds.length,
+  };
+}
+
+export function toClassroomGameView(game: ClassroomGameRecord): ClassroomGameView {
+  return {
+    id: toIdString(game._id) as string,
+    gameId: game.gameId,
+    gameLabel: getGameLabel(game.gameId),
+    studentDisplayName: game.studentDisplayName ?? null,
+    completedLevelCount: game.completedLevels?.length ?? 0,
+    completedStageCount: game.completedStageIds?.length ?? 0,
+    lastUpdated: game.lastUpdated,
+  };
+}
+
+export function toClassroomQuizView(quiz: ClassroomQuizRecord): ClassroomQuizView {
+  return {
+    id: toIdString(quiz._id) as string,
+    studentDisplayName: quiz.studentDisplayName ?? null,
+    completed: Boolean(quiz.completed),
+    updatedAt: quiz.updatedAt ?? null,
+    statesOfMatterScoreBefore: quiz.statesOfMatterScoreBefore,
+    stateOfMatterScoreAfter: quiz.stateOfMatterScoreAfter,
+    penguinRunScoreBefore: quiz.penguinRunScoreBefore,
+    penguinRunScoreAfter: quiz.penguinRunScoreAfter,
+  };
+}

--- a/src/lib/server/classroomHistory.ts
+++ b/src/lib/server/classroomHistory.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import {
   QuizScoreRecord,
   averagePercent,
@@ -377,8 +378,10 @@ export type ClassroomQuizView = QuizScoreRecord & {
 export function toClassroomRosterView(entry: ClassroomRosterEntry): ClassroomRosterView {
   return {
     // The participant id is stable within the class and carries no external identity, unlike the
-    // participantKey it replaces.
-    id: entry.participantIds[0] ?? entry.participantKey,
+    // participantKey it replaces. When there is no participant id the key is hashed rather than
+    // emitted — a participantKey is `clerk:<userId>`, so passing it through would leak exactly the
+    // identity this projection exists to withhold.
+    id: entry.participantIds[0] ?? createHash("sha256").update(entry.participantKey).digest("hex").slice(0, 24),
     displayName: entry.displayName,
     joinedAt: entry.joinedAt,
     lastSeenAt: entry.lastSeenAt,

--- a/src/lib/server/classroomHistory.ts
+++ b/src/lib/server/classroomHistory.ts
@@ -1,0 +1,343 @@
+import {
+  QuizScoreRecord,
+  averagePercent,
+  formatPercent,
+  getPostQuizPercentages,
+  getPreQuizPercentages,
+  getQuizResultBreakdown,
+} from "@/lib/quizScoring";
+
+export type IdLike = string | { toString(): string };
+
+export type ClassroomSessionState = "active" | "expired" | "closed";
+
+export type ClassroomSessionRecord = {
+  _id: IdLike;
+  title: string;
+  status: "active" | "closed";
+  createdAt: Date;
+  expiresAt: Date;
+  closedAt?: Date | null;
+  continuedFromId?: IdLike | null;
+  rootSessionId?: IdLike | null;
+};
+
+export type ClassroomParticipantRecord = {
+  _id: IdLike;
+  sessionId: IdLike;
+  participantKey: string;
+  displayName: string;
+  joinedAt: Date;
+  lastSeenAt: Date;
+};
+
+export type ClassroomAccessCodeRecord = {
+  _id: IdLike;
+  sessionId: IdLike;
+  code: string;
+  isActive: boolean;
+  createdAt: Date;
+  lastSeenAt?: Date | null;
+};
+
+export type ClassroomGameRecord = {
+  _id: IdLike;
+  classroomSessionId?: string | null;
+  classroomParticipantId?: string | null;
+  gameId: string;
+  lastUpdated: Date;
+  studentDisplayName?: string | null;
+  completedLevels?: number[];
+  completedStageIds?: string[];
+};
+
+export type ClassroomQuizRecord = QuizScoreRecord & {
+  _id: IdLike;
+  classroomSessionId?: string | null;
+  classroomParticipantId?: string | null;
+  studentDisplayName?: string | null;
+  completed?: boolean;
+  updatedAt?: Date;
+};
+
+export type ClassroomClass = {
+  classId: string;
+  title: string;
+  state: ClassroomSessionState;
+  sessions: ClassroomSessionRecord[];
+  latestSession: ClassroomSessionRecord;
+  createdAt: Date;
+  expiresAt: Date;
+  closedAt: Date | null;
+  reopenCount: number;
+};
+
+export type ClassroomRosterEntry = {
+  participantKey: string;
+  participantIds: string[];
+  displayName: string;
+  joinedAt: Date;
+  lastSeenAt: Date;
+  sessionIds: string[];
+};
+
+export type ClassroomActivityItem = {
+  id: string;
+  description: string;
+  occurredAt: Date;
+};
+
+export type ClassroomClassSummary = ClassroomClass & {
+  participantCount: number;
+  gamesPlayed: number;
+  quizzesRecorded: number;
+  averagePreQuizScore: number | null;
+  averagePostQuizScore: number | null;
+  lastActivityAt: Date | null;
+  activeAccessCode: string | null;
+};
+
+export function toIdString(value: IdLike | null | undefined): string | null {
+  if (value === null || value === undefined) return null;
+  const asString = typeof value === "string" ? value : String(value);
+  return asString.length > 0 ? asString : null;
+}
+
+/**
+ * A class is a continuation chain, not a single session. `rootSessionId` is null on the original
+ * session, so the chain is always addressed by the id of the session that started it.
+ */
+export function getClassId(session: Pick<ClassroomSessionRecord, "_id" | "rootSessionId">) {
+  return toIdString(session.rootSessionId) ?? (toIdString(session._id) as string);
+}
+
+export function resolveClassroomSessionState(
+  session: Pick<ClassroomSessionRecord, "status" | "expiresAt">,
+  now: Date = new Date(),
+): ClassroomSessionState {
+  if (session.status === "closed") return "closed";
+  return session.expiresAt.getTime() <= now.getTime() ? "expired" : "active";
+}
+
+export function isClassroomSessionJoinable(
+  session: Pick<ClassroomSessionRecord, "status" | "expiresAt">,
+  now: Date = new Date(),
+) {
+  return resolveClassroomSessionState(session, now) === "active";
+}
+
+function compareByTime(a: Date, b: Date) {
+  return a.getTime() - b.getTime();
+}
+
+export function groupSessionsIntoClasses(sessions: ClassroomSessionRecord[], now: Date = new Date()): ClassroomClass[] {
+  const chains = new Map<string, ClassroomSessionRecord[]>();
+
+  for (const session of sessions) {
+    const classId = getClassId(session);
+    const chain = chains.get(classId);
+    if (chain) {
+      chain.push(session);
+    } else {
+      chains.set(classId, [session]);
+    }
+  }
+
+  return Array.from(chains.entries())
+    .map(([classId, chain]) => {
+      const ordered = [...chain].sort((a, b) => compareByTime(a.createdAt, b.createdAt));
+      const latestSession = ordered[ordered.length - 1];
+
+      return {
+        classId,
+        title: latestSession.title,
+        state: resolveClassroomSessionState(latestSession, now),
+        sessions: ordered,
+        latestSession,
+        createdAt: ordered[0].createdAt,
+        expiresAt: latestSession.expiresAt,
+        closedAt: latestSession.closedAt ?? null,
+        reopenCount: ordered.length - 1,
+      };
+    })
+    .sort((a, b) => compareByTime(b.latestSession.createdAt, a.latestSession.createdAt));
+}
+
+/**
+ * Reopening a class creates a new session, so a returning student produces a second participant
+ * row that shares the original `participantKey`. Collapsing on that key is what keeps a roster
+ * continuous across reopens without mutating any historical record.
+ */
+export function buildClassroomRoster(participants: ClassroomParticipantRecord[]): ClassroomRosterEntry[] {
+  const entries = new Map<string, ClassroomRosterEntry>();
+
+  for (const participant of participants) {
+    const participantId = toIdString(participant._id);
+    const sessionId = toIdString(participant.sessionId);
+    const existing = entries.get(participant.participantKey);
+
+    if (!existing) {
+      entries.set(participant.participantKey, {
+        participantKey: participant.participantKey,
+        participantIds: participantId ? [participantId] : [],
+        displayName: participant.displayName,
+        joinedAt: participant.joinedAt,
+        lastSeenAt: participant.lastSeenAt,
+        sessionIds: sessionId ? [sessionId] : [],
+      });
+      continue;
+    }
+
+    if (participantId && !existing.participantIds.includes(participantId)) {
+      existing.participantIds.push(participantId);
+    }
+    if (sessionId && !existing.sessionIds.includes(sessionId)) {
+      existing.sessionIds.push(sessionId);
+    }
+    if (compareByTime(participant.joinedAt, existing.joinedAt) < 0) {
+      existing.joinedAt = participant.joinedAt;
+    }
+    if (compareByTime(participant.lastSeenAt, existing.lastSeenAt) >= 0) {
+      existing.lastSeenAt = participant.lastSeenAt;
+      existing.displayName = participant.displayName;
+    }
+  }
+
+  return Array.from(entries.values()).sort((a, b) => compareByTime(a.joinedAt, b.joinedAt));
+}
+
+export function getGameLabel(gameId: string) {
+  return gameId === "statesOfMatterGame" ? "States of Matter" : "Penguin Run";
+}
+
+export function buildClassroomActivity(input: {
+  classTitle: string;
+  participants: ClassroomParticipantRecord[];
+  gameData: ClassroomGameRecord[];
+  quizzes: ClassroomQuizRecord[];
+}): ClassroomActivityItem[] {
+  return [
+    ...input.participants.map((participant) => ({
+      id: `participant-${toIdString(participant._id)}`,
+      description: `${participant.displayName} joined ${input.classTitle}.`,
+      occurredAt: participant.joinedAt,
+    })),
+    ...input.gameData.map((game) => ({
+      id: `game-${toIdString(game._id)}`,
+      description: `${game.studentDisplayName || "A student"} played ${getGameLabel(game.gameId)}.`,
+      occurredAt: game.lastUpdated,
+    })),
+    ...input.quizzes.flatMap((quiz) => {
+      if (!quiz.updatedAt) return [];
+      const updatedAt = quiz.updatedAt;
+
+      return getQuizResultBreakdown(quiz).map((result) => ({
+        id: `quiz-${toIdString(quiz._id)}-${result.key}`,
+        description: `${quiz.studentDisplayName || "A student"} completed ${result.label} with ${formatPercent(result.score)}.`,
+        occurredAt: updatedAt,
+      }));
+    }),
+  ].sort((a, b) => compareByTime(b.occurredAt, a.occurredAt));
+}
+
+function getLastActivityAt(input: {
+  participants: ClassroomParticipantRecord[];
+  gameData: ClassroomGameRecord[];
+  quizzes: ClassroomQuizRecord[];
+}): Date | null {
+  const timestamps = [
+    ...input.participants.map((participant) => participant.lastSeenAt),
+    ...input.gameData.map((game) => game.lastUpdated),
+    ...input.quizzes.map((quiz) => quiz.updatedAt),
+  ].filter((value): value is Date => value instanceof Date);
+
+  if (timestamps.length === 0) return null;
+  return timestamps.reduce((latest, value) => (compareByTime(value, latest) > 0 ? value : latest));
+}
+
+export function summarizeClassroomClass(
+  classroomClass: ClassroomClass,
+  input: {
+    participants: ClassroomParticipantRecord[];
+    accessCodes: ClassroomAccessCodeRecord[];
+    gameData: ClassroomGameRecord[];
+    quizzes: ClassroomQuizRecord[];
+  },
+): ClassroomClassSummary {
+  const prePercentages = input.quizzes.flatMap(getPreQuizPercentages);
+  const postPercentages = input.quizzes.flatMap(getPostQuizPercentages);
+  const latestSessionId = toIdString(classroomClass.latestSession._id);
+  const activeAccessCode = input.accessCodes.find(
+    (accessCode) => accessCode.isActive && toIdString(accessCode.sessionId) === latestSessionId,
+  );
+
+  return {
+    ...classroomClass,
+    participantCount: buildClassroomRoster(input.participants).length,
+    gamesPlayed: input.gameData.length,
+    quizzesRecorded: input.quizzes.length,
+    averagePreQuizScore: prePercentages.length ? averagePercent(prePercentages) : null,
+    averagePostQuizScore: postPercentages.length ? averagePercent(postPercentages) : null,
+    lastActivityAt: getLastActivityAt(input),
+    // Only a class whose newest session is still live can hand out a working code.
+    activeAccessCode: classroomClass.state === "active" && activeAccessCode ? activeAccessCode.code : null,
+  };
+}
+
+/**
+ * Buckets records that carry a `classroomSessionId` by the class their session belongs to, so a
+ * single query per collection can serve a list of classes.
+ */
+export function bucketBySessionOwner<T extends { classroomSessionId?: string | null }>(
+  records: T[],
+  classIdBySessionId: Map<string, string>,
+): Map<string, T[]> {
+  const buckets = new Map<string, T[]>();
+
+  for (const record of records) {
+    const classId = record.classroomSessionId ? classIdBySessionId.get(record.classroomSessionId) : undefined;
+    if (!classId) continue;
+
+    const bucket = buckets.get(classId);
+    if (bucket) {
+      bucket.push(record);
+    } else {
+      buckets.set(classId, [record]);
+    }
+  }
+
+  return buckets;
+}
+
+export function bucketByParticipantSession<T extends { sessionId: IdLike }>(
+  records: T[],
+  classIdBySessionId: Map<string, string>,
+): Map<string, T[]> {
+  const buckets = new Map<string, T[]>();
+
+  for (const record of records) {
+    const sessionId = toIdString(record.sessionId);
+    const classId = sessionId ? classIdBySessionId.get(sessionId) : undefined;
+    if (!classId) continue;
+
+    const bucket = buckets.get(classId);
+    if (bucket) {
+      bucket.push(record);
+    } else {
+      buckets.set(classId, [record]);
+    }
+  }
+
+  return buckets;
+}
+
+export function buildClassIdBySessionId(sessions: ClassroomSessionRecord[]) {
+  const classIdBySessionId = new Map<string, string>();
+
+  for (const session of sessions) {
+    const sessionId = toIdString(session._id);
+    if (sessionId) classIdBySessionId.set(sessionId, getClassId(session));
+  }
+
+  return classIdBySessionId;
+}

--- a/src/lib/server/educatorClassroom.test.ts
+++ b/src/lib/server/educatorClassroom.test.ts
@@ -64,18 +64,23 @@ describe("closeActiveClassroomSessions", () => {
     );
   });
 
-  it("spares the sessions the caller asked to keep open", async () => {
-    const closed = await closeActiveClassroomSessions(TEACHER_ID, { exceptSessionIds: [SESSION_A], now: NOW });
+  it("excludes a spared chain in the query rather than after the fact", async () => {
+    const ROOT = new mongoose.Types.ObjectId();
+    await closeActiveClassroomSessions(TEACHER_ID, { exceptChainRootId: ROOT, now: NOW });
 
-    expect(closed).toEqual([SESSION_B]);
-    expect(mocks.sessionUpdateMany).toHaveBeenCalledWith({ _id: { $in: [SESSION_B] } }, expect.any(Array));
+    // Filtering in the query is what makes a continuation created mid-flight still count as part of
+    // the spared class.
+    expect(mocks.sessionFind).toHaveBeenCalledWith({
+      teacherId: TEACHER_ID,
+      status: "active",
+      $nor: [{ _id: ROOT }, { rootSessionId: ROOT }],
+    });
   });
 
-  it("does not write anything when every session is already excluded", async () => {
-    const closed = await closeActiveClassroomSessions(TEACHER_ID, {
-      exceptSessionIds: [SESSION_A, SESSION_B],
-      now: NOW,
-    });
+  it("does not write anything when there is no active session to close", async () => {
+    mocks.sessionFind.mockReturnValue({ lean: () => Promise.resolve([]) });
+
+    const closed = await closeActiveClassroomSessions(TEACHER_ID, { now: NOW });
 
     expect(closed).toEqual([]);
     expect(mocks.sessionUpdateMany).not.toHaveBeenCalled();

--- a/src/lib/server/educatorClassroom.test.ts
+++ b/src/lib/server/educatorClassroom.test.ts
@@ -1,0 +1,140 @@
+import mongoose from "mongoose";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  sessionFind: vi.fn(),
+  sessionUpdateMany: vi.fn(),
+  codeCreate: vi.fn(),
+  codeUpdateMany: vi.fn(),
+  userFindOne: vi.fn(),
+  teacherFindOneAndUpdate: vi.fn(),
+}));
+
+vi.mock("@/database/classroomSessionSchema", () => ({
+  default: { find: mocks.sessionFind, updateMany: mocks.sessionUpdateMany },
+}));
+vi.mock("@/database/studentAccessCodeSchema", () => ({
+  default: { create: mocks.codeCreate, updateMany: mocks.codeUpdateMany },
+}));
+vi.mock("@/database/userSchema", () => ({ default: { findOne: mocks.userFindOne } }));
+vi.mock("@/database/teacherSchema", () => ({ default: { findOneAndUpdate: mocks.teacherFindOneAndUpdate } }));
+
+import {
+  closeActiveClassroomSessions,
+  generateAccessCode,
+  getTeacherForCurrentUser,
+  issueAccessCode,
+} from "@/lib/server/educatorClassroom";
+
+const NOW = new Date("2026-08-22T18:00:00.000Z");
+const TEACHER_ID = new mongoose.Types.ObjectId();
+const SESSION_A = new mongoose.Types.ObjectId();
+const SESSION_B = new mongoose.Types.ObjectId();
+
+function duplicateKeyError() {
+  return Object.assign(new Error("E11000 duplicate key"), { code: 11000 });
+}
+
+describe("closeActiveClassroomSessions", () => {
+  beforeEach(() => {
+    mocks.sessionFind.mockReturnValue({ lean: () => Promise.resolve([{ _id: SESSION_A }, { _id: SESSION_B }]) });
+    mocks.sessionUpdateMany.mockResolvedValue({});
+    mocks.codeUpdateMany.mockResolvedValue({});
+  });
+
+  it("closes every active session and deactivates its codes", async () => {
+    const closed = await closeActiveClassroomSessions(TEACHER_ID, { now: NOW });
+
+    expect(closed).toEqual([SESSION_A, SESSION_B]);
+    expect(mocks.sessionUpdateMany).toHaveBeenCalledWith(
+      { _id: { $in: [SESSION_A, SESSION_B] } },
+      { $set: { status: "closed", closedAt: NOW } },
+    );
+    expect(mocks.codeUpdateMany).toHaveBeenCalledWith(
+      { sessionId: { $in: [SESSION_A, SESSION_B] }, isActive: true },
+      { $set: { isActive: false } },
+    );
+  });
+
+  it("spares the sessions the caller asked to keep open", async () => {
+    const closed = await closeActiveClassroomSessions(TEACHER_ID, { exceptSessionIds: [SESSION_A], now: NOW });
+
+    expect(closed).toEqual([SESSION_B]);
+    expect(mocks.sessionUpdateMany).toHaveBeenCalledWith({ _id: { $in: [SESSION_B] } }, expect.anything());
+  });
+
+  it("does not write anything when every session is already excluded", async () => {
+    const closed = await closeActiveClassroomSessions(TEACHER_ID, {
+      exceptSessionIds: [SESSION_A, SESSION_B],
+      now: NOW,
+    });
+
+    expect(closed).toEqual([]);
+    expect(mocks.sessionUpdateMany).not.toHaveBeenCalled();
+    expect(mocks.codeUpdateMany).not.toHaveBeenCalled();
+  });
+});
+
+describe("issueAccessCode", () => {
+  it("retries past a colliding code and returns the one that stuck", async () => {
+    mocks.codeCreate.mockRejectedValueOnce(duplicateKeyError()).mockResolvedValueOnce({});
+
+    const code = await issueAccessCode(SESSION_A);
+
+    expect(mocks.codeCreate).toHaveBeenCalledTimes(2);
+    expect(code).toBe(mocks.codeCreate.mock.calls[1][0].code);
+    expect(code).toMatch(/^[A-Z]{6}-[A-Z0-9]{3}$/);
+  });
+
+  it("surfaces failures that are not collisions instead of burning retries", async () => {
+    mocks.codeCreate.mockRejectedValue(new Error("connection lost"));
+
+    await expect(issueAccessCode(SESSION_A)).rejects.toThrow("connection lost");
+    expect(mocks.codeCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up after repeated collisions rather than looping", async () => {
+    mocks.codeCreate.mockRejectedValue(duplicateKeyError());
+
+    await expect(issueAccessCode(SESSION_A)).rejects.toThrow(/duplicate key/);
+    expect(mocks.codeCreate).toHaveBeenCalledTimes(5);
+  });
+});
+
+describe("generateAccessCode", () => {
+  it("produces a six letter prefix and three alphanumeric suffix", () => {
+    for (let attempt = 0; attempt < 25; attempt += 1) {
+      expect(generateAccessCode()).toMatch(/^[A-Z]{6}-[A-Z0-9]{3}$/);
+    }
+  });
+});
+
+describe("getTeacherForCurrentUser", () => {
+  it("refuses users who are not educators", async () => {
+    mocks.userFindOne.mockReturnValue({ lean: () => Promise.resolve({ role: "player" }) });
+
+    const result = await getTeacherForCurrentUser("user_1");
+
+    expect("error" in result && result.error.status).toBe(403);
+    expect(mocks.teacherFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it("refuses signed-in users with no stored profile", async () => {
+    mocks.userFindOne.mockReturnValue({ lean: () => Promise.resolve(null) });
+
+    const result = await getTeacherForCurrentUser("user_1");
+
+    expect("error" in result && result.error.status).toBe(403);
+  });
+
+  it("returns the educator's teacher id", async () => {
+    mocks.userFindOne.mockReturnValue({
+      lean: () => Promise.resolve({ role: "educator", name: "Ada", email: "ada@example.com" }),
+    });
+    mocks.teacherFindOneAndUpdate.mockReturnValue({ lean: () => Promise.resolve({ _id: TEACHER_ID }) });
+
+    const result = await getTeacherForCurrentUser("user_1");
+
+    expect(result).toEqual({ teacherId: TEACHER_ID });
+  });
+});

--- a/src/lib/server/educatorClassroom.test.ts
+++ b/src/lib/server/educatorClassroom.test.ts
@@ -46,10 +46,18 @@ describe("closeActiveClassroomSessions", () => {
     const closed = await closeActiveClassroomSessions(TEACHER_ID, { now: NOW });
 
     expect(closed).toEqual([SESSION_A, SESSION_B]);
-    expect(mocks.sessionUpdateMany).toHaveBeenCalledWith(
-      { _id: { $in: [SESSION_A, SESSION_B] } },
-      { $set: { status: "closed", closedAt: NOW } },
-    );
+    // A pipeline update, so each session can keep the time it actually ended: an already-expired
+    // session is stamped with its own expiry rather than the moment something else closed it.
+    expect(mocks.sessionUpdateMany).toHaveBeenCalledWith({ _id: { $in: [SESSION_A, SESSION_B] } }, [
+      {
+        $set: {
+          status: "closed",
+          closedAt: {
+            $ifNull: ["$closedAt", { $cond: [{ $lte: ["$expiresAt", NOW] }, "$expiresAt", NOW] }],
+          },
+        },
+      },
+    ]);
     expect(mocks.codeUpdateMany).toHaveBeenCalledWith(
       { sessionId: { $in: [SESSION_A, SESSION_B] }, isActive: true },
       { $set: { isActive: false } },
@@ -60,7 +68,7 @@ describe("closeActiveClassroomSessions", () => {
     const closed = await closeActiveClassroomSessions(TEACHER_ID, { exceptSessionIds: [SESSION_A], now: NOW });
 
     expect(closed).toEqual([SESSION_B]);
-    expect(mocks.sessionUpdateMany).toHaveBeenCalledWith({ _id: { $in: [SESSION_B] } }, expect.anything());
+    expect(mocks.sessionUpdateMany).toHaveBeenCalledWith({ _id: { $in: [SESSION_B] } }, expect.any(Array));
   });
 
   it("does not write anything when every session is already excluded", async () => {

--- a/src/lib/server/educatorClassroom.ts
+++ b/src/lib/server/educatorClassroom.ts
@@ -73,10 +73,21 @@ export async function issueAccessCode(sessionId: mongoose.Types.ObjectId | strin
  */
 export async function closeActiveClassroomSessions(
   teacherId: mongoose.Types.ObjectId | string,
-  options: { exceptSessionIds?: Array<mongoose.Types.ObjectId | string>; now?: Date } = {},
+  options: {
+    exceptSessionIds?: Array<mongoose.Types.ObjectId | string>;
+    exceptChainRootId?: mongoose.Types.ObjectId | string;
+    now?: Date;
+  } = {},
 ) {
   const except = (options.exceptSessionIds ?? []).map((id) => String(id));
-  const activeSessions = await ClassroomSession.find({ teacherId, status: "active" }).lean<
+
+  // Excluding a whole chain has to happen in the query, not against a list of ids read earlier. A
+  // concurrent reopen can add a session to the chain in between, and a stale list would treat that
+  // brand new continuation as an unrelated class and close it.
+  const rootId = options.exceptChainRootId ? new mongoose.Types.ObjectId(String(options.exceptChainRootId)) : null;
+  const chainFilter = rootId ? { $nor: [{ _id: rootId }, { rootSessionId: rootId }] } : {};
+
+  const activeSessions = await ClassroomSession.find({ teacherId, status: "active", ...chainFilter }).lean<
     Array<{ _id: mongoose.Types.ObjectId }>
   >();
 

--- a/src/lib/server/educatorClassroom.ts
+++ b/src/lib/server/educatorClassroom.ts
@@ -69,18 +69,12 @@ export async function issueAccessCode(sessionId: mongoose.Types.ObjectId | strin
 
 /**
  * Closes every active session for a teacher and deactivates its codes, so only one class of theirs
- * can accept joins at a time. Sessions listed in `exceptSessionIds` are left untouched.
+ * can accept joins at a time. A whole continuation chain can be spared via `exceptChainRootId`.
  */
 export async function closeActiveClassroomSessions(
   teacherId: mongoose.Types.ObjectId | string,
-  options: {
-    exceptSessionIds?: Array<mongoose.Types.ObjectId | string>;
-    exceptChainRootId?: mongoose.Types.ObjectId | string;
-    now?: Date;
-  } = {},
+  options: { exceptChainRootId?: mongoose.Types.ObjectId | string; now?: Date } = {},
 ) {
-  const except = (options.exceptSessionIds ?? []).map((id) => String(id));
-
   // Excluding a whole chain has to happen in the query, not against a list of ids read earlier. A
   // concurrent reopen can add a session to the chain in between, and a stale list would treat that
   // brand new continuation as an unrelated class and close it.
@@ -91,7 +85,7 @@ export async function closeActiveClassroomSessions(
     Array<{ _id: mongoose.Types.ObjectId }>
   >();
 
-  const closingIds = activeSessions.map((session) => session._id).filter((id) => !except.includes(String(id)));
+  const closingIds = activeSessions.map((session) => session._id);
 
   if (closingIds.length === 0) return [];
 

--- a/src/lib/server/educatorClassroom.ts
+++ b/src/lib/server/educatorClassroom.ts
@@ -1,0 +1,110 @@
+import mongoose from "mongoose";
+import { NextResponse } from "next/server";
+import ClassroomSession from "@/database/classroomSessionSchema";
+import StudentAccessCode from "@/database/studentAccessCodeSchema";
+import Teacher from "@/database/teacherSchema";
+import User from "@/database/userSchema";
+
+export const SESSION_DURATION_MS = 8 * 60 * 60 * 1000;
+
+const ACCESS_CODE_ATTEMPTS = 5;
+
+export type EducatorLookup = { teacherId: mongoose.Types.ObjectId } | { error: NextResponse };
+
+export function generateAccessCode() {
+  const letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  const alphanumeric = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  const pick = (source: string, count: number) =>
+    Array.from({ length: count }, () => source[Math.floor(Math.random() * source.length)]).join("");
+
+  return `${pick(letters, 6)}-${pick(alphanumeric, 3)}`;
+}
+
+export async function getTeacherForCurrentUser(userId: string): Promise<EducatorLookup> {
+  const dbUser = await User.findOne({ clerkId: userId }).lean<{
+    name?: string;
+    email?: string;
+    role?: string;
+  } | null>();
+
+  if (dbUser?.role !== "educator") {
+    return { error: NextResponse.json({ error: "Educator access required." }, { status: 403 }) };
+  }
+
+  const teacher = await Teacher.findOneAndUpdate(
+    { clerkId: userId },
+    {
+      $set: {
+        name: dbUser.name ?? "Educator",
+        email: dbUser.email ?? `${userId}@example.invalid`,
+      },
+    },
+    { new: true, upsert: true, setDefaultsOnInsert: true, runValidators: true },
+  ).lean<{ _id: mongoose.Types.ObjectId } | null>();
+
+  if (!teacher) {
+    return { error: NextResponse.json({ error: "Unable to create educator profile." }, { status: 500 }) };
+  }
+
+  return { teacherId: teacher._id };
+}
+
+/**
+ * Mints a fresh access code for a session. The unique partial index on active codes means a
+ * collision is possible but rare, so retry a bounded number of times before surfacing the error.
+ */
+export async function issueAccessCode(sessionId: mongoose.Types.ObjectId | string) {
+  for (let attempt = 0; attempt < ACCESS_CODE_ATTEMPTS; attempt += 1) {
+    const code = generateAccessCode();
+    try {
+      await StudentAccessCode.create({ sessionId, code });
+      return code;
+    } catch (error: any) {
+      if (error?.code !== 11000 || attempt === ACCESS_CODE_ATTEMPTS - 1) throw error;
+    }
+  }
+
+  throw new Error("Unable to generate a unique access code.");
+}
+
+/**
+ * Closes every active session for a teacher and deactivates its codes, so only one class of theirs
+ * can accept joins at a time. Sessions listed in `exceptSessionIds` are left untouched.
+ */
+export async function closeActiveClassroomSessions(
+  teacherId: mongoose.Types.ObjectId | string,
+  options: { exceptSessionIds?: Array<mongoose.Types.ObjectId | string>; now?: Date } = {},
+) {
+  const except = (options.exceptSessionIds ?? []).map((id) => String(id));
+  const activeSessions = await ClassroomSession.find({ teacherId, status: "active" }).lean<
+    Array<{ _id: mongoose.Types.ObjectId }>
+  >();
+
+  const closingIds = activeSessions.map((session) => session._id).filter((id) => !except.includes(String(id)));
+
+  if (closingIds.length === 0) return [];
+
+  await Promise.all([
+    ClassroomSession.updateMany(
+      { _id: { $in: closingIds } },
+      { $set: { status: "closed", closedAt: options.now ?? new Date() } },
+    ),
+    StudentAccessCode.updateMany({ sessionId: { $in: closingIds }, isActive: true }, { $set: { isActive: false } }),
+  ]);
+
+  return closingIds;
+}
+
+/**
+ * Read-only educator lookup for server-rendered pages. Unlike `getTeacherForCurrentUser` it never
+ * creates a Teacher record, so simply viewing a page cannot mutate data.
+ */
+export async function findEducatorTeacher(userId: string) {
+  const dbUser = await User.findOne({ clerkId: userId }).lean<{ name?: string; role?: string } | null>();
+  if (dbUser?.role !== "educator") return null;
+
+  const teacher = await Teacher.findOne({ clerkId: userId }).lean<{ _id: mongoose.Types.ObjectId } | null>();
+  if (!teacher) return null;
+
+  return { name: dbUser.name ?? "Educator", teacherId: teacher._id };
+}

--- a/src/lib/server/educatorClassroom.ts
+++ b/src/lib/server/educatorClassroom.ts
@@ -95,11 +95,22 @@ export async function closeActiveClassroomSessions(
 
   if (closingIds.length === 0) return [];
 
+  const closedAt = options.now ?? new Date();
+
   await Promise.all([
-    ClassroomSession.updateMany(
-      { _id: { $in: closingIds } },
-      { $set: { status: "closed", closedAt: options.now ?? new Date() } },
-    ),
+    // An expired session is still stored as "active", so stamp it with when it actually ended
+    // rather than when something else happened to close it. Matches how a reopen closes its own
+    // chain, and keeps the history timeline honest.
+    ClassroomSession.updateMany({ _id: { $in: closingIds } }, [
+      {
+        $set: {
+          status: "closed",
+          closedAt: {
+            $ifNull: ["$closedAt", { $cond: [{ $lte: ["$expiresAt", closedAt] }, "$expiresAt", closedAt] }],
+          },
+        },
+      },
+    ]),
     StudentAccessCode.updateMany({ sessionId: { $in: closingIds }, isActive: true }, { $set: { isActive: false } }),
   ]);
 

--- a/src/lib/server/educatorClassroom.ts
+++ b/src/lib/server/educatorClassroom.ts
@@ -98,13 +98,16 @@ export async function closeActiveClassroomSessions(
 /**
  * Read-only educator lookup for server-rendered pages. Unlike `getTeacherForCurrentUser` it never
  * creates a Teacher record, so simply viewing a page cannot mutate data.
+ *
+ * Returns null only when the user is not an educator. The Teacher record is created lazily on first
+ * class creation, so `teacherId` is null for an educator who has signed up but never run a class —
+ * that is someone with no classes, not someone without access.
  */
 export async function findEducatorTeacher(userId: string) {
   const dbUser = await User.findOne({ clerkId: userId }).lean<{ name?: string; role?: string } | null>();
   if (dbUser?.role !== "educator") return null;
 
   const teacher = await Teacher.findOne({ clerkId: userId }).lean<{ _id: mongoose.Types.ObjectId } | null>();
-  if (!teacher) return null;
 
-  return { name: dbUser.name ?? "Educator", teacherId: teacher._id };
+  return { name: dbUser.name ?? "Educator", teacherId: teacher?._id ?? null };
 }


### PR DESCRIPTION
Closes #54.

## Problem

Educators could only ever see their newest classroom session. Starting a new class closed the previous one and deactivated its access code, so there was no way to review prior learning, resume a class after an interruption, or recover a class closed by accident. The underlying participants, game saves, and quiz results were all still stored — just unreachable.

## Approach: a class is a continuation chain

Reopening appends a **linked continuation session** rather than rewriting the closed one. `ClassroomSession` gains two fields:

- `continuedFromId` — the session this one continues
- `rootSessionId` — denormalized head of the chain (null on an original), so a class is always addressed by `rootSessionId ?? _id`

Historical records keep pointing at the sessions that produced them; only new activity lands on the continuation. Nothing is deleted, merged, or re-attributed. Rosters stay continuous across reopens by collapsing participants on their `participantKey`, which is stable for the same student across sessions.

## What's new

**Educator UI**
- `/educatorClassHistory` — every class with state (active / expired / closed), participant count, games played, average pre/post quiz scores, last activity, and the active code if there is one.
- `/educatorClassHistory/[classId]` — session timeline with each session's access codes and whether they're retired, merged roster, quiz results, game progress, activity feed, and the reopen action.
- Educator dashboard gains a "Class History" link and a "View full class record" link.

**API**
- `GET /api/classroom-sessions/history` — the caller's classes.
- `GET /api/classroom-sessions/history/[classId]` — one class's full record.
- `POST /api/classroom-sessions/history/[classId]/reopen` — reopen.

## Reopen behavior

- Mints a **new** access code and retires every code the chain has ever issued, so a student holding an old code cannot rejoin.
- Closes any other class the educator still has open, matching how starting a new class already behaves.
- Closes an expired session against **its own expiry**, not the reopen time, so the timeline reports when it actually ended.
- Reopening an already-live class is a no-op that returns the existing code, so a double-click cannot churn codes.
- If code generation fails, the continuation is rolled back — otherwise the class would sit active-but-unjoinable and could never be reopened again.
- Accepts any session id in a chain and normalizes to the root.

## Authorization

- Reads are limited to the owning educator, with the existing admin bypass (`canEducatorReadClassroom`).
- Reopening requires educator standing and has **no** admin bypass — read access does not extend to acting on another educator's class.
- Unauthorized reads answer `404`, not `403`, so one educator cannot probe for another's classes. This follows the existing `GET /api/gameData/[saveId]` precedent.

## Cleanup

The educator dashboard's inline quiz-scoring and activity-feed logic moved into shared modules (`src/lib/quizScoring.ts`, `src/lib/server/classroomHistory.ts`) now that the history views need the same logic — the dashboard page drops ~110 lines with no behavior change. The session-closing and access-code primitives are shared between the create and reopen paths (`src/lib/server/educatorClassroom.ts`).

## Tests

33 new tests. Session-state resolution (closed vs. merely expired, including the exact expiry instant), chain grouping, roster merging across reopens, summary metrics, record bucketing, activity ordering; the full reopen path including cross-educator refusal, stale-code retirement, other-class closing, expiry-accurate closing, live-class no-op, rollback, and id normalization; and route authorization for all three endpoints.

## Known follow-up (not in scope for #54)

A student rejoining a reopened class gets a new `ClassroomParticipant` row, so their **own** saved progress does not carry over — their prior saves are owned by `participant:<oldParticipantId>`. The educator history view shows everything correctly, and no records are lost. Resolving participant lineage on the student side touches the same ownership resolution as #56, so it belongs in its own PR; the chain plus `participantKey` already makes it resolvable without a backfill.

## Verification

- `npm test -- --run` — 66 passed
- `npm run lint` — clean
- `npx tsc --noEmit` — clean across `src/`
- `next build` — full build succeeds, all three routes and both pages registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)