### PR TITLE
Give the admin dashboard real classroom analytics

### DIFF
--- a/docs/api-authorization.md
+++ b/docs/api-authorization.md
@@ -17,6 +17,7 @@ Classroom records are keyed to the authorized participant, including for signed-
 | Route                                             | Method           | Access                                                         |
 | ------------------------------------------------- | ---------------- | -------------------------------------------------------------- |
 | `/api/admin/:id/role`                             | PATCH            | Administrator                                                  |
+| `/api/admin/analytics`                            | GET              | Administrator                                                  |
 | `/api/auth/admin-access`                          | GET              | Administrator                                                  |
 | `/api/classroom-sessions`                         | GET, POST, PATCH | Signed-in educator; sessions are teacher-scoped                |
 | `/api/classroom-sessions/join`                    | POST             | Public with an active access code; issues classroom credential |
@@ -30,6 +31,7 @@ Classroom records are keyed to the authorized participant, including for signed-
 | `/api/gameData`                                   | POST             | Signed-in owner or credentialed classroom participant          |
 | `/api/gameData/:saveId`                           | GET              | Owner, administrator, or educator who owns the classroom       |
 | `/api/gameData/:saveId`                           | PATCH            | Owner only                                                     |
+| `/api/gameData/mine`                              | GET              | Signed-in user or classroom participant; own records only      |
 | `/api/quiz`                                       | GET              | Administrator                                                  |
 | `/api/quiz`                                       | POST             | Signed-in owner or credentialed classroom participant          |
 | `/api/quiz/:id`                                   | GET              | Owner, administrator, or educator who owns the classroom       |

--- a/src/app/adminDashboard/adminDashboard.module.css
+++ b/src/app/adminDashboard/adminDashboard.module.css
@@ -270,3 +270,48 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* Classroom breakdown: six columns, and each row links through to that class's full record. */
+.classroomHeader,
+.classroomRow {
+  display: grid;
+  grid-template-columns: 2fr 1.4fr 0.9fr 0.8fr 0.7fr 0.7fr;
+  gap: 12px;
+  align-items: center;
+}
+
+.classroomHeader {
+  padding: 0 4px 10px;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: #8a92a6;
+}
+
+.classroomRow {
+  padding: 12px 4px;
+  border-top: 1px solid #eef1f6;
+  text-decoration: none;
+  color: inherit;
+}
+
+.classroomRow:hover {
+  background: #f8fbff;
+}
+
+.scopeNote {
+  margin: 0 0 12px;
+  font-size: 14px;
+  line-height: 1.45;
+  color: #6b7280;
+}
+
+@media (max-width: 900px) {
+  .classroomHeader {
+    display: none;
+  }
+
+  .classroomRow {
+    grid-template-columns: 1fr 1fr;
+  }
+}

--- a/src/app/adminDashboard/page.tsx
+++ b/src/app/adminDashboard/page.tsx
@@ -36,16 +36,47 @@ type ActivityRow = {
   lastUpdatedMs: number;
 };
 
+type SessionState = "active" | "expired" | "closed";
+
+type AdminClassRow = {
+  classId: string;
+  title: string;
+  educatorName: string;
+  state: SessionState;
+  participantCount: number;
+  gamesPlayed: number;
+  averageGain: number | null;
+  lastActivityAt: string | null;
+};
+
+type AdminAnalytics = {
+  scope: { includedStates: SessionState[] };
+  sessionCounts: { active: number; expired: number; closed: number; total: number };
+  classCount: number;
+  learners: { personal: number; classroom: number; total: number };
+  gamesPlayed: number;
+  averageGain: number | null;
+  classes: AdminClassRow[];
+  classesTruncated: boolean;
+};
+
 type DashboardData = {
   users: AdminUser[];
   quizzes: QuizRecord[];
   gameData: GameDataRecord[];
+  analytics: AdminAnalytics | null;
 };
 
 type StatCard = {
   label: string;
   value: string;
   helper: string;
+};
+
+const STATE_LABELS: Record<SessionState, string> = {
+  active: "Active",
+  expired: "Expired",
+  closed: "Closed",
 };
 
 const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
@@ -105,35 +136,6 @@ function getAverageScore(quiz?: QuizRecord) {
   return scores.reduce((sum, score) => sum + score, 0) / scores.length;
 }
 
-function getAverageGain(quizzes: QuizRecord[]) {
-  const gains: number[] = [];
-
-  quizzes.forEach((quiz) => {
-    if (
-      typeof quiz.penguinRunScoreBefore === "number" &&
-      quiz.penguinRunScoreBefore >= 0 &&
-      typeof quiz.penguinRunScoreAfter === "number" &&
-      quiz.penguinRunScoreAfter >= 0
-    ) {
-      gains.push(((quiz.penguinRunScoreAfter - quiz.penguinRunScoreBefore) / PENGUIN_RUN_QUESTION_COUNT) * 100);
-    }
-
-    if (
-      typeof quiz.statesOfMatterScoreBefore === "number" &&
-      quiz.statesOfMatterScoreBefore >= 0 &&
-      typeof quiz.stateOfMatterScoreAfter === "number" &&
-      quiz.stateOfMatterScoreAfter >= 0
-    ) {
-      gains.push(
-        ((quiz.stateOfMatterScoreAfter - quiz.statesOfMatterScoreBefore) / STATES_OF_MATTER_QUESTION_COUNT) * 100,
-      );
-    }
-  });
-
-  if (gains.length === 0) return 0;
-  return gains.reduce((sum, gain) => sum + gain, 0) / gains.length;
-}
-
 function getWeeklyChartData(gameData: GameDataRecord[]) {
   const today = new Date();
   const bars = DAY_LABELS.map((label, offset) => {
@@ -161,7 +163,7 @@ function getWeeklyChartData(gameData: GameDataRecord[]) {
 }
 
 export default function AdminDashboardPage() {
-  const [data, setData] = useState<DashboardData>({ users: [], quizzes: [], gameData: [] });
+  const [data, setData] = useState<DashboardData>({ users: [], quizzes: [], gameData: [], analytics: null });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
@@ -173,24 +175,26 @@ export default function AdminDashboardPage() {
         setLoading(true);
         setError("");
 
-        const [usersResponse, quizzesResponse, gameDataResponse] = await Promise.all([
+        const [usersResponse, quizzesResponse, gameDataResponse, analyticsResponse] = await Promise.all([
           fetch("/api/users", { cache: "no-store" }),
           fetch("/api/quiz", { cache: "no-store" }),
           fetch("/api/gameData", { cache: "no-store" }),
+          fetch("/api/admin/analytics", { cache: "no-store" }),
         ]);
 
-        if (!usersResponse.ok || !quizzesResponse.ok || !gameDataResponse.ok) {
+        if (!usersResponse.ok || !quizzesResponse.ok || !gameDataResponse.ok || !analyticsResponse.ok) {
           throw new Error("Failed to load dashboard data.");
         }
 
-        const [users, quizzes, gameData] = await Promise.all([
+        const [users, quizzes, gameData, analytics] = await Promise.all([
           usersResponse.json() as Promise<AdminUser[]>,
           quizzesResponse.json() as Promise<QuizRecord[]>,
           gameDataResponse.json() as Promise<GameDataRecord[]>,
+          analyticsResponse.json() as Promise<AdminAnalytics>,
         ]);
 
         if (!isActive) return;
-        setData({ users, quizzes, gameData });
+        setData({ users, quizzes, gameData, analytics });
       } catch (loadError) {
         console.error("Failed to load admin dashboard:", loadError);
         if (isActive) setError("Could not load admin statistics.");
@@ -225,32 +229,38 @@ export default function AdminDashboardPage() {
   }, [data.gameData]);
 
   const statCards = useMemo<StatCard[]>(() => {
-    const averageGain = getAverageGain(data.quizzes);
-    const gainPrefix = averageGain > 0 ? "+" : "";
+    const analytics = data.analytics;
+    const gain = analytics?.averageGain ?? null;
+    const gainPrefix = gain !== null && gain > 0 ? "+" : "";
 
     return [
       {
-        label: "TOTAL STUDENTS",
-        value: data.users.length.toLocaleString(),
-        helper: "All registered users",
+        label: "TOTAL LEARNERS",
+        value: (analytics ? analytics.learners.total : data.users.length).toLocaleString(),
+        helper: analytics
+          ? `${analytics.learners.personal.toLocaleString()} with accounts, ${analytics.learners.classroom.toLocaleString()} in classrooms`
+          : "All registered users",
       },
       {
         label: "ACTIVE CLASSROOMS",
-        value: "0",
-        helper: "Dummy data for now",
+        value: (analytics?.sessionCounts.active ?? 0).toLocaleString(),
+        helper: analytics
+          ? `${analytics.sessionCounts.expired.toLocaleString()} expired, ${analytics.sessionCounts.closed.toLocaleString()} closed`
+          : "—",
       },
       {
         label: "GAMES PLAYED",
         value: data.gameData.length.toLocaleString(),
-        helper: "From saved game records",
+        helper: "All saved records, personal and classroom",
       },
       {
         label: "AVG PRE→POST GAIN",
-        value: `${gainPrefix}${Math.round(averageGain)}%`,
-        helper: "Across completed post-quizzes",
+        // Distinguishes "no measured gain" from "a gain of zero", which the previous card could not.
+        value: gain === null ? "—" : `${gainPrefix}${Math.round(gain)}%`,
+        helper: gain === null ? "No completed pre and post pairs yet" : "Across classes in scope",
       },
     ];
-  }, [data.gameData.length, data.quizzes, data.users.length]);
+  }, [data.analytics, data.gameData.length, data.users.length]);
 
   const activityRows = useMemo<ActivityRow[]>(() => {
     return data.users
@@ -322,6 +332,53 @@ export default function AdminDashboardPage() {
                 )}
               </div>
             </section>
+
+            {data.analytics ? (
+              <section className={styles.activityCard}>
+                <h2 className={styles.cardTitle}>Classrooms</h2>
+                <p className={styles.scopeNote}>
+                  Showing {data.analytics.classCount.toLocaleString()} class
+                  {data.analytics.classCount === 1 ? "" : "es"} across{" "}
+                  {data.analytics.scope.includedStates.map((state) => STATE_LABELS[state].toLowerCase()).join(", ")}{" "}
+                  sessions.
+                  {data.analytics.classesTruncated ? " Older classes are not listed." : ""}
+                </p>
+
+                <div className={styles.classroomHeader}>
+                  <span>CLASS</span>
+                  <span>EDUCATOR</span>
+                  <span>STATE</span>
+                  <span>STUDENTS</span>
+                  <span>GAMES</span>
+                  <span>GAIN</span>
+                </div>
+
+                <div className={styles.tableBody}>
+                  {data.analytics.classes.length === 0 ? (
+                    <p className={styles.emptyState}>No classrooms in this scope.</p>
+                  ) : (
+                    data.analytics.classes.map((row) => (
+                      <a
+                        key={row.classId}
+                        href={`/educatorClassHistory/${row.classId}`}
+                        className={styles.classroomRow}
+                      >
+                        <span className={styles.userName}>{row.title}</span>
+                        <span className={styles.gameName}>{row.educatorName}</span>
+                        <span className={styles.gameName}>{STATE_LABELS[row.state]}</span>
+                        <span className={styles.scoreValue}>{row.participantCount.toLocaleString()}</span>
+                        <span className={styles.scoreValue}>{row.gamesPlayed.toLocaleString()}</span>
+                        <span className={styles.scoreValue}>
+                          {row.averageGain === null
+                            ? "—"
+                            : `${row.averageGain > 0 ? "+" : ""}${Math.round(row.averageGain)}%`}
+                        </span>
+                      </a>
+                    ))
+                  )}
+                </div>
+              </section>
+            ) : null}
 
             <section className={styles.chartCard}>
               <h2 className={styles.cardTitle}>Games Played — Last 7 Days</h2>

--- a/src/app/api/admin/analytics/route.test.ts
+++ b/src/app/api/admin/analytics/route.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mocks = vi.hoisted(() => ({
+  auth: vi.fn(),
+  connectDB: vi.fn(),
+  loadAdminAnalytics: vi.fn(),
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({ auth: mocks.auth }));
+vi.mock("@/database/db", () => ({ default: mocks.connectDB }));
+vi.mock("@/lib/server/adminAnalytics", () => ({
+  ALL_SESSION_STATES: ["active", "expired", "closed"],
+  DEFAULT_ADMIN_CLASS_LIMIT: 50,
+  loadAdminAnalytics: mocks.loadAdminAnalytics,
+}));
+
+import { GET } from "@/app/api/admin/analytics/route";
+
+const request = (search = "") => new NextRequest(`http://localhost/api/admin/analytics${search}`);
+
+describe("GET /api/admin/analytics", () => {
+  beforeEach(() => {
+    mocks.loadAdminAnalytics.mockResolvedValue({ sessionCounts: { active: 1, expired: 0, closed: 2, total: 3 } });
+  });
+
+  it("rejects anonymous callers", async () => {
+    mocks.auth.mockResolvedValue({ userId: null, sessionClaims: null });
+
+    expect((await GET(request())).status).toBe(401);
+    expect(mocks.loadAdminAnalytics).not.toHaveBeenCalled();
+  });
+
+  it("rejects signed-in non-administrators, including educators", async () => {
+    for (const role of ["player", "parent", "educator"]) {
+      mocks.auth.mockResolvedValue({ userId: "user_1", sessionClaims: { role } });
+      expect((await GET(request())).status).toBe(403);
+    }
+
+    // Cross-class aggregate data must not be reachable without the admin role.
+    expect(mocks.loadAdminAnalytics).not.toHaveBeenCalled();
+  });
+
+  it("serves administrators", async () => {
+    mocks.auth.mockResolvedValue({ userId: "admin_1", sessionClaims: { role: "admin" } });
+
+    const response = await GET(request());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ sessionCounts: { total: 3 } });
+  });
+
+  it("passes through the supported filters", async () => {
+    mocks.auth.mockResolvedValue({ userId: "admin_1", sessionClaims: { role: "admin" } });
+
+    await GET(request("?classId=c1&educatorId=e1&gameId=penguinRunGame&states=active,closed&from=2026-08-01"));
+
+    expect(mocks.loadAdminAnalytics).toHaveBeenCalledWith(
+      expect.objectContaining({
+        classId: "c1",
+        educatorId: "e1",
+        gameId: "penguinRunGame",
+        states: ["active", "closed"],
+        from: new Date("2026-08-01"),
+      }),
+    );
+  });
+
+  it("ignores unrecognised states and unparseable dates rather than filtering on them", async () => {
+    mocks.auth.mockResolvedValue({ userId: "admin_1", sessionClaims: { role: "admin" } });
+
+    await GET(request("?states=bogus&from=not-a-date"));
+
+    expect(mocks.loadAdminAnalytics).toHaveBeenCalledWith(
+      expect.objectContaining({ states: undefined, from: undefined }),
+    );
+  });
+
+  it("caps the class limit", async () => {
+    mocks.auth.mockResolvedValue({ userId: "admin_1", sessionClaims: { role: "admin" } });
+
+    await GET(request("?limit=99999"));
+
+    expect(mocks.loadAdminAnalytics).toHaveBeenCalledWith(expect.objectContaining({ limit: 200 }));
+  });
+});

--- a/src/app/api/admin/analytics/route.ts
+++ b/src/app/api/admin/analytics/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import connectDB from "@/database/db";
+import { getRequestActor, requireAdmin } from "@/lib/server/apiAuthorization";
+import { ClassroomSessionState } from "@/lib/server/classroomHistory";
+import { ALL_SESSION_STATES, DEFAULT_ADMIN_CLASS_LIMIT, loadAdminAnalytics } from "@/lib/server/adminAnalytics";
+
+const MAX_CLASS_LIMIT = 200;
+
+function parseStates(value: string | null): ClassroomSessionState[] | undefined {
+  if (!value) return undefined;
+  const requested = value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry): entry is ClassroomSessionState => (ALL_SESSION_STATES as string[]).includes(entry));
+  return requested.length ? requested : undefined;
+}
+
+function parseDate(value: string | null) {
+  if (!value) return undefined;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+function parseLimit(value: string | null) {
+  const parsed = Number.parseInt(value ?? "", 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_ADMIN_CLASS_LIMIT;
+  return Math.min(parsed, MAX_CLASS_LIMIT);
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const admin = requireAdmin(await getRequestActor());
+    if (!admin.ok) return admin.response;
+
+    await connectDB();
+
+    const params = request.nextUrl.searchParams;
+    const analytics = await loadAdminAnalytics({
+      classId: params.get("classId") ?? undefined,
+      educatorId: params.get("educatorId") ?? undefined,
+      gameId: params.get("gameId") ?? undefined,
+      from: parseDate(params.get("from")),
+      to: parseDate(params.get("to")),
+      states: parseStates(params.get("states")),
+      limit: parseLimit(params.get("limit")),
+    });
+
+    return NextResponse.json(analytics, { status: 200 });
+  } catch (error) {
+    console.error("GET /api/admin/analytics error:", error);
+    return NextResponse.json({ error: "Failed to load analytics." }, { status: 500 });
+  }
+}

--- a/src/lib/server/adminAnalytics.test.ts
+++ b/src/lib/server/adminAnalytics.test.ts
@@ -1,0 +1,176 @@
+import mongoose from "mongoose";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  sessionFind: vi.fn(),
+  participantFind: vi.fn(),
+  gameFind: vi.fn(),
+  gameDistinct: vi.fn(),
+  quizFind: vi.fn(),
+  teacherFind: vi.fn(),
+}));
+
+vi.mock("@/database/classroomSessionSchema", () => ({ default: { find: mocks.sessionFind } }));
+vi.mock("@/database/classroomParticipantSchema", () => ({ default: { find: mocks.participantFind } }));
+vi.mock("@/database/gameDataSchema", () => ({ default: { find: mocks.gameFind, distinct: mocks.gameDistinct } }));
+vi.mock("@/database/quizSchema", () => ({ default: { find: mocks.quizFind } }));
+vi.mock("@/database/teacherSchema", () => ({ default: { find: mocks.teacherFind } }));
+
+import { loadAdminAnalytics } from "@/lib/server/adminAnalytics";
+
+const NOW_ISH = new Date();
+const TEACHER = new mongoose.Types.ObjectId();
+const LIVE_ROOT = new mongoose.Types.ObjectId();
+const CLOSED_ROOT = new mongoose.Types.ObjectId();
+
+const liveSession = {
+  _id: LIVE_ROOT,
+  teacherId: TEACHER,
+  title: "Period 1",
+  status: "active" as const,
+  createdAt: new Date(NOW_ISH.getTime() - 3_600_000),
+  expiresAt: new Date(NOW_ISH.getTime() + 3_600_000),
+  closedAt: null,
+  rootSessionId: null,
+};
+
+const closedSession = {
+  _id: CLOSED_ROOT,
+  teacherId: TEACHER,
+  title: "Period 2",
+  status: "closed" as const,
+  createdAt: new Date(NOW_ISH.getTime() - 7_200_000),
+  expiresAt: new Date(NOW_ISH.getTime() - 3_600_000),
+  closedAt: new Date(NOW_ISH.getTime() - 3_600_000),
+  rootSessionId: null,
+};
+
+function selectSortLean(value: unknown) {
+  return { select: () => ({ sort: () => ({ lean: async () => value }) }) };
+}
+function selectLean(value: unknown) {
+  return { select: () => ({ lean: async () => value }) };
+}
+
+describe("loadAdminAnalytics", () => {
+  beforeEach(() => {
+    mocks.sessionFind.mockReturnValue(selectSortLean([liveSession, closedSession]));
+    mocks.participantFind.mockReturnValue(
+      selectLean([
+        {
+          _id: "p1",
+          sessionId: LIVE_ROOT,
+          participantKey: "clerk:student-a",
+          displayName: "A",
+          joinedAt: NOW_ISH,
+          lastSeenAt: NOW_ISH,
+        },
+        {
+          _id: "p2",
+          sessionId: CLOSED_ROOT,
+          participantKey: "guest:student-b",
+          displayName: "B",
+          joinedAt: NOW_ISH,
+          lastSeenAt: NOW_ISH,
+        },
+      ]),
+    );
+    mocks.gameFind.mockReturnValue(
+      selectLean([
+        { _id: "g1", classroomSessionId: String(LIVE_ROOT), gameId: "penguinRunGame", lastUpdated: NOW_ISH },
+        { _id: "g2", classroomSessionId: String(CLOSED_ROOT), gameId: "statesOfMatterGame", lastUpdated: NOW_ISH },
+      ]),
+    );
+    mocks.quizFind.mockReturnValue(
+      selectLean([
+        {
+          _id: "q1",
+          classroomSessionId: String(LIVE_ROOT),
+          statesOfMatterScoreBefore: 1,
+          stateOfMatterScoreAfter: 3,
+          penguinRunScoreBefore: -1,
+          penguinRunScoreAfter: -1,
+          updatedAt: NOW_ISH,
+        },
+      ]),
+    );
+    mocks.teacherFind.mockReturnValue(selectLean([{ _id: TEACHER, name: "Ms Rivera" }]));
+    mocks.gameDistinct.mockResolvedValue(["clerk_personal_1", "clerk_personal_2"]);
+  });
+
+  it("counts active, closed, and expired sessions separately", async () => {
+    const analytics = await loadAdminAnalytics();
+
+    expect(analytics.sessionCounts).toMatchObject({ active: 1, closed: 1, expired: 0, total: 2 });
+  });
+
+  it("states the scope its aggregates were computed over", async () => {
+    const analytics = await loadAdminAnalytics();
+
+    // The old dashboard mixed closed-class records into totals with no way to tell.
+    expect(analytics.scope.includedStates).toEqual(["active", "expired", "closed"]);
+  });
+
+  it("counts classroom learners without requiring a personal account", async () => {
+    const analytics = await loadAdminAnalytics();
+
+    // Both a signed-in and a guest participant count, and neither is a Clerk user record.
+    expect(analytics.learners).toMatchObject({ classroom: 2, personal: 2, total: 4 });
+  });
+
+  it("excludes closed classes from aggregates when the scope asks for active only", async () => {
+    const analytics = await loadAdminAnalytics({ states: ["active"] });
+
+    expect(analytics.scope.includedStates).toEqual(["active"]);
+    expect(analytics.classCount).toBe(1);
+    expect(analytics.classes[0].title).toBe("Period 1");
+    // Session counts describe the whole system, so they stay unfiltered.
+    expect(analytics.sessionCounts.total).toBe(2);
+    expect(analytics.gamesPlayed).toBe(1);
+  });
+
+  it("attributes each class to its educator", async () => {
+    const analytics = await loadAdminAnalytics();
+
+    expect(analytics.classes.every((row) => row.educatorName === "Ms Rivera")).toBe(true);
+  });
+
+  it("reports a pre-to-post gain per class and overall", async () => {
+    const analytics = await loadAdminAnalytics({ states: ["active"] });
+
+    // 1/3 -> 3/3 is 33.3% -> 100%.
+    expect(analytics.classes[0].averagePreQuizScore).toBeCloseTo(100 / 3);
+    expect(analytics.classes[0].averagePostQuizScore).toBe(100);
+    expect(analytics.classes[0].averageGain).toBeCloseTo(100 - 100 / 3);
+    expect(analytics.averageGain).toBeCloseTo(100 - 100 / 3);
+  });
+
+  it("reports no gain rather than zero when nothing was measured", async () => {
+    mocks.quizFind.mockReturnValue(selectLean([]));
+
+    const analytics = await loadAdminAnalytics();
+
+    expect(analytics.averagePreQuizScore).toBeNull();
+    expect(analytics.averageGain).toBeNull();
+  });
+
+  it("filters game records by game when asked", async () => {
+    await loadAdminAnalytics({ gameId: "penguinRunGame" });
+
+    expect(mocks.gameFind).toHaveBeenCalledWith(expect.objectContaining({ gameId: "penguinRunGame" }));
+  });
+
+  it("narrows to one class when given a class id", async () => {
+    const analytics = await loadAdminAnalytics({ classId: String(CLOSED_ROOT) });
+
+    expect(analytics.classCount).toBe(1);
+    expect(analytics.classes[0].classId).toBe(String(CLOSED_ROOT));
+  });
+
+  it("reports truncation instead of silently dropping classes", async () => {
+    const analytics = await loadAdminAnalytics({ limit: 1 });
+
+    expect(analytics.classes).toHaveLength(1);
+    expect(analytics.classesTruncated).toBe(true);
+  });
+});

--- a/src/lib/server/adminAnalytics.ts
+++ b/src/lib/server/adminAnalytics.ts
@@ -1,0 +1,240 @@
+import mongoose from "mongoose";
+import ClassroomParticipant from "@/database/classroomParticipantSchema";
+import ClassroomSession from "@/database/classroomSessionSchema";
+import GameData from "@/database/gameDataSchema";
+import Quiz from "@/database/quizSchema";
+import Teacher from "@/database/teacherSchema";
+import { averagePercent, getPostQuizPercentages, getPreQuizPercentages } from "@/lib/quizScoring";
+import {
+  ClassroomGameRecord,
+  ClassroomParticipantRecord,
+  ClassroomQuizRecord,
+  ClassroomSessionRecord,
+  ClassroomSessionState,
+  buildClassIdBySessionId,
+  buildClassroomRoster,
+  bucketByParticipantSession,
+  bucketBySessionOwner,
+  getClassId,
+  groupSessionsIntoClasses,
+  resolveClassroomSessionState,
+  toIdString,
+} from "@/lib/server/classroomHistory";
+
+export const ALL_SESSION_STATES: ClassroomSessionState[] = ["active", "expired", "closed"];
+export const DEFAULT_ADMIN_CLASS_LIMIT = 50;
+
+export type AdminAnalyticsFilters = {
+  classId?: string;
+  educatorId?: string;
+  gameId?: string;
+  from?: Date;
+  to?: Date;
+  states?: ClassroomSessionState[];
+  limit?: number;
+};
+
+export type AdminClassRow = {
+  classId: string;
+  title: string;
+  educatorId: string | null;
+  educatorName: string;
+  state: ClassroomSessionState;
+  sessionCount: number;
+  participantCount: number;
+  gamesPlayed: number;
+  quizzesRecorded: number;
+  averagePreQuizScore: number | null;
+  averagePostQuizScore: number | null;
+  averageGain: number | null;
+  createdAt: Date;
+  lastActivityAt: Date | null;
+};
+
+export type AdminAnalytics = {
+  /**
+   * Every aggregate below is computed over exactly this scope. Stated explicitly because the
+   * previous dashboard mixed closed-class records into totals with no way to tell.
+   */
+  scope: {
+    includedStates: ClassroomSessionState[];
+    from: Date | null;
+    to: Date | null;
+    gameId: string | null;
+    classId: string | null;
+    educatorId: string | null;
+  };
+  sessionCounts: Record<ClassroomSessionState, number> & { total: number };
+  classCount: number;
+  learners: { personal: number; classroom: number; total: number };
+  gamesPlayed: number;
+  quizzesRecorded: number;
+  averagePreQuizScore: number | null;
+  averagePostQuizScore: number | null;
+  averageGain: number | null;
+  classes: AdminClassRow[];
+  classesTruncated: boolean;
+};
+
+function withinRange(value: Date | null | undefined, from?: Date, to?: Date) {
+  if (!value) return !from && !to;
+  if (from && value.getTime() < from.getTime()) return false;
+  if (to && value.getTime() > to.getTime()) return false;
+  return true;
+}
+
+function gainFrom(pre: number | null, post: number | null) {
+  return pre === null || post === null ? null : post - pre;
+}
+
+/**
+ * Classroom-aware analytics for the administrator dashboard.
+ *
+ * Classroom records are owned by `participant:<id>` rather than a Clerk id, which is why the
+ * previous per-user table dropped them entirely. Here they are counted through the classroom
+ * sessions that produced them, so classroom learners are represented without needing a personal
+ * account.
+ */
+export async function loadAdminAnalytics(filters: AdminAnalyticsFilters = {}): Promise<AdminAnalytics> {
+  const now = new Date();
+  const states = filters.states?.length ? filters.states : ALL_SESSION_STATES;
+  const limit = filters.limit ?? DEFAULT_ADMIN_CLASS_LIMIT;
+
+  const sessionQuery: Record<string, unknown> = {};
+  if (filters.educatorId && mongoose.Types.ObjectId.isValid(filters.educatorId)) {
+    sessionQuery.teacherId = new mongoose.Types.ObjectId(filters.educatorId);
+  }
+
+  const allSessions = await ClassroomSession.find(sessionQuery)
+    .select("teacherId title status createdAt expiresAt closedAt continuedFromId rootSessionId")
+    .sort({ createdAt: 1 })
+    .lean<Array<ClassroomSessionRecord & { _id: mongoose.Types.ObjectId; teacherId: mongoose.Types.ObjectId }>>();
+
+  const sessionCounts = { active: 0, expired: 0, closed: 0, total: allSessions.length };
+  for (const session of allSessions) {
+    sessionCounts[resolveClassroomSessionState(session, now)] += 1;
+  }
+
+  // Chains are grouped before filtering so a class is judged by the state of its newest session,
+  // matching how the educator history view describes it.
+  let classes = groupSessionsIntoClasses(allSessions, now).filter((entry) => states.includes(entry.state));
+  if (filters.classId) {
+    classes = classes.filter((entry) => entry.classId === filters.classId);
+  }
+
+  const keptClassIds = new Set(classes.map((entry) => entry.classId));
+  const sessions = allSessions.filter((session) => keptClassIds.has(getClassId(session)));
+  const sessionObjectIds = sessions.map((session) => session._id);
+  const sessionIdStrings = sessions.map((session) => String(session._id));
+
+  const gameQuery: Record<string, unknown> = { classroomSessionId: { $in: sessionIdStrings } };
+  if (filters.gameId) gameQuery.gameId = filters.gameId;
+
+  const [participants, gameData, quizzes, teachers, personalLearnerIds] = await Promise.all([
+    ClassroomParticipant.find({ sessionId: { $in: sessionObjectIds } })
+      .select("sessionId participantKey displayName joinedAt lastSeenAt")
+      .lean<ClassroomParticipantRecord[]>(),
+    GameData.find(gameQuery)
+      .select("classroomSessionId gameId lastUpdated studentDisplayName completedLevels completedStageIds")
+      .lean<ClassroomGameRecord[]>(),
+    Quiz.find({ classroomSessionId: { $in: sessionIdStrings } })
+      .select(
+        "classroomSessionId updatedAt statesOfMatterScoreBefore stateOfMatterScoreAfter penguinRunScoreBefore penguinRunScoreAfter",
+      )
+      .lean<ClassroomQuizRecord[]>(),
+    Teacher.find({}).select("name").lean<Array<{ _id: mongoose.Types.ObjectId; name?: string }>>(),
+    // Personal learners are records whose owner is a Clerk id rather than a participant key.
+    GameData.distinct("userId", { classroomSessionId: null }),
+  ]);
+
+  const teacherNames = new Map(teachers.map((teacher) => [String(teacher._id), teacher.name ?? "Educator"]));
+  const classIdBySessionId = buildClassIdBySessionId(sessions);
+  const teacherIdByClassId = new Map(
+    sessions.map((session) => [getClassId(session), String(session.teacherId)] as const),
+  );
+
+  const participantsByClass = bucketByParticipantSession(participants, classIdBySessionId);
+  const gameDataByClass = bucketBySessionOwner(gameData, classIdBySessionId);
+  const quizzesByClass = bucketBySessionOwner(quizzes, classIdBySessionId);
+
+  const rows: AdminClassRow[] = classes.map((classroomClass) => {
+    const classParticipants = participantsByClass.get(classroomClass.classId) ?? [];
+    const classGames = (gameDataByClass.get(classroomClass.classId) ?? []).filter((game) =>
+      withinRange(game.lastUpdated, filters.from, filters.to),
+    );
+    const classQuizzes = (quizzesByClass.get(classroomClass.classId) ?? []).filter((quiz) =>
+      withinRange(quiz.updatedAt ?? null, filters.from, filters.to),
+    );
+
+    const pre = classQuizzes.flatMap(getPreQuizPercentages);
+    const post = classQuizzes.flatMap(getPostQuizPercentages);
+    const averagePre = pre.length ? averagePercent(pre) : null;
+    const averagePost = post.length ? averagePercent(post) : null;
+    const timestamps = [
+      ...classParticipants.map((participant) => participant.lastSeenAt),
+      ...classGames.map((game) => game.lastUpdated),
+      ...classQuizzes.map((quiz) => quiz.updatedAt),
+    ].filter((value): value is Date => value instanceof Date);
+    const educatorId = teacherIdByClassId.get(classroomClass.classId) ?? null;
+
+    return {
+      classId: classroomClass.classId,
+      title: classroomClass.title,
+      educatorId,
+      educatorName: (educatorId && teacherNames.get(educatorId)) || "Educator",
+      state: classroomClass.state,
+      sessionCount: classroomClass.sessions.length,
+      participantCount: buildClassroomRoster(classParticipants).length,
+      gamesPlayed: classGames.length,
+      quizzesRecorded: classQuizzes.length,
+      averagePreQuizScore: averagePre,
+      averagePostQuizScore: averagePost,
+      averageGain: gainFrom(averagePre, averagePost),
+      createdAt: classroomClass.createdAt,
+      lastActivityAt: timestamps.length
+        ? timestamps.reduce((latest, value) => (value.getTime() > latest.getTime() ? value : latest))
+        : null,
+    };
+  });
+
+  rows.sort((a, b) => (b.lastActivityAt?.getTime() ?? 0) - (a.lastActivityAt?.getTime() ?? 0));
+
+  const overallPre = rows.flatMap((row) => (row.averagePreQuizScore === null ? [] : [row.averagePreQuizScore]));
+  const overallPost = rows.flatMap((row) => (row.averagePostQuizScore === null ? [] : [row.averagePostQuizScore]));
+  const averagePre = overallPre.length ? averagePercent(overallPre) : null;
+  const averagePost = overallPost.length ? averagePercent(overallPost) : null;
+
+  const classroomLearners = new Set(
+    participants
+      .filter((participant) => keptClassIds.has(classIdBySessionId.get(toIdString(participant.sessionId) ?? "") ?? ""))
+      .map((participant) => participant.participantKey),
+  );
+
+  return {
+    scope: {
+      includedStates: states,
+      from: filters.from ?? null,
+      to: filters.to ?? null,
+      gameId: filters.gameId ?? null,
+      classId: filters.classId ?? null,
+      educatorId: filters.educatorId ?? null,
+    },
+    sessionCounts,
+    classCount: rows.length,
+    learners: {
+      personal: personalLearnerIds.filter((id: unknown) => typeof id === "string" && !id.startsWith("participant:"))
+        .length,
+      classroom: classroomLearners.size,
+      total:
+        personalLearnerIds.filter((id: unknown) => typeof id === "string" && !id.startsWith("participant:")).length +
+        classroomLearners.size,
+    },
+    gamesPlayed: rows.reduce((sum, row) => sum + row.gamesPlayed, 0),
+    quizzesRecorded: rows.reduce((sum, row) => sum + row.quizzesRecorded, 0),
+    averagePreQuizScore: averagePre,
+    averagePostQuizScore: averagePost,
+    averageGain: gainFrom(averagePre, averagePost),
+    classes: rows.slice(0, limit),
+    classesTruncated: rows.length > limit,
+  };
+}


### PR DESCRIPTION
Closes #55.

## Problem

The admin dashboard was reporting numbers it could not stand behind:

- `ACTIVE CLASSROOMS` was hardcoded to `"0"`, with helper text reading **"Dummy data for now"**.
- Aggregates mixed records from closed classes into totals with no way to tell which sessions were included.
- The per-user table is keyed by Clerk id, so classroom participants — whose records are owned by `participant:<id>` — were **dropped entirely** rather than counted.
- `AVG PRE→POST GAIN` rendered `0%` whether the gain was genuinely zero or simply never measured.

## What's added

`GET /api/admin/analytics`, administrator-only, built on the continuation-chain model already used for educator history:

- **Session counts** for active, expired, and closed, reported separately.
- **An explicit scope** on every response, so a reader can tell which session states, date range, game, class, and educator the aggregates cover.
- **Classroom learners counted without a personal account**, deduplicated by `participantKey` so a student who rejoins after a reopen is one learner, not two.
- **Per-class rows** with educator attribution, participant count, games played, and pre-to-post gain.
- **Filters** by class, educator, game, date range, and session state.
- **Explicit truncation** — `classesTruncated` rather than silently dropping older classes.

## Dashboard

Real active-classroom count with expired/closed as context; total learners split into account holders and classroom participants; and a Classrooms table where each row links through to that class's full record. A gain that was never measured now renders `—` rather than `0%`.

## Privacy

Aggregates are built from the same projected views as the educator history, so no Clerk id, quiz id, or per-question answer reaches the client. Note that a participant's `participantKey` is `clerk:<userId>` — it is used for counting server-side and never serialized.

## Tests

16 new. Coverage includes: active/closed/expired counted separately; the stated scope; classroom learners counted without a Clerk account; scope filtering excluding closed classes from aggregates while system-wide session counts stay unfiltered; educator attribution; per-class and overall gain; "no measured gain" distinguished from zero; game and class filters; truncation reported. Route tests confirm anonymous, player, parent, **and educator** callers are all refused, and that unrecognised states and unparseable dates are ignored rather than filtered on.

## Verification

- `npm test -- --run` — 103 passed
- `npm run lint` — 0 errors
- `npx tsc --noEmit` — clean across `src/`
- `next build` — compiles, route registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)