### PR TITLE
Carry student progress across a reopened class

### DIFF
--- a/src/app/api/gameData/mine/route.test.ts
+++ b/src/app/api/gameData/mine/route.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mocks = vi.hoisted(() => ({
+  connectDB: vi.fn(),
+  find: vi.fn(),
+  select: vi.fn(),
+  sort: vi.fn(),
+  lean: vi.fn(),
+  auth: vi.fn(),
+  resolveDataPrincipal: vi.fn(),
+  resolveClassroomOwnerKeys: vi.fn(),
+}));
+
+vi.mock("@clerk/nextjs/server", () => ({ auth: mocks.auth }));
+vi.mock("@/database/db", () => ({ default: mocks.connectDB }));
+vi.mock("@/database/gameDataSchema", () => ({ default: { find: mocks.find } }));
+vi.mock("@/lib/server/classroomAuthorization", () => ({
+  resolveDataPrincipal: mocks.resolveDataPrincipal,
+  resolveClassroomOwnerKeys: mocks.resolveClassroomOwnerKeys,
+}));
+
+import { GET } from "@/app/api/gameData/mine/route";
+
+const request = (search = "") => new NextRequest(`http://localhost/api/gameData/mine${search}`);
+
+const CLASSROOM = {
+  participantId: "participant-new",
+  sessionId: "session-continuation",
+  displayName: "Ada",
+  clerkId: "clerk-student",
+};
+
+describe("GET /api/gameData/mine", () => {
+  beforeEach(() => {
+    mocks.auth.mockResolvedValue({ userId: "clerk-student", sessionClaims: { role: "player" } });
+    mocks.lean.mockResolvedValue([
+      { saveId: "save-new", gameId: "statesOfMatterGame", lastUpdated: new Date(), completedLevels: [1, 2] },
+    ]);
+    mocks.sort.mockReturnValue({ lean: mocks.lean });
+    mocks.select.mockReturnValue({ sort: mocks.sort });
+    mocks.find.mockReturnValue({ select: mocks.select });
+    mocks.resolveDataPrincipal.mockResolvedValue({
+      ok: true,
+      value: { ownerId: "participant:participant-new", actor: {}, classroom: CLASSROOM },
+    });
+    mocks.resolveClassroomOwnerKeys.mockResolvedValue(["participant:participant-new", "participant:participant-old"]);
+  });
+
+  it("refuses a caller the principal resolver rejects", async () => {
+    mocks.resolveDataPrincipal.mockResolvedValue({
+      ok: false,
+      response: new Response(null, { status: 401 }) as never,
+    });
+
+    expect((await GET(request())).status).toBe(401);
+    expect(mocks.find).not.toHaveBeenCalled();
+  });
+
+  it("refuses an anonymous caller with no owner", async () => {
+    mocks.resolveDataPrincipal.mockResolvedValue({ ok: true, value: { ownerId: null, actor: {}, classroom: null } });
+
+    expect((await GET(request())).status).toBe(401);
+    expect(mocks.find).not.toHaveBeenCalled();
+  });
+
+  it("searches the classroom participant's whole lineage so a reopen does not lose progress", async () => {
+    const response = await GET(request());
+
+    expect(response.status).toBe(200);
+    expect(mocks.resolveClassroomOwnerKeys).toHaveBeenCalledWith(CLASSROOM);
+    expect(mocks.find).toHaveBeenCalledWith({
+      userId: { $in: ["participant:participant-new", "participant:participant-old"] },
+      gameId: { $in: ["statesOfMatterGame", "penguinRunGame"] },
+    });
+    await expect(response.json()).resolves.toMatchObject({
+      saves: [{ saveId: "save-new", completedLevelCount: 2 }],
+    });
+  });
+
+  it("uses only the personal owner key when there is no classroom context", async () => {
+    mocks.resolveDataPrincipal.mockResolvedValue({
+      ok: true,
+      value: { ownerId: "clerk-student", actor: {}, classroom: null },
+    });
+
+    await GET(request());
+
+    expect(mocks.resolveClassroomOwnerKeys).not.toHaveBeenCalled();
+    expect(mocks.find).toHaveBeenCalledWith(expect.objectContaining({ userId: { $in: ["clerk-student"] } }));
+  });
+
+  it("ignores an unsupported gameId rather than filtering on it", async () => {
+    await GET(request("?gameId=../../etc/passwd"));
+
+    expect(mocks.find).toHaveBeenCalledWith(
+      expect.objectContaining({ gameId: { $in: ["statesOfMatterGame", "penguinRunGame"] } }),
+    );
+  });
+
+  it("filters to a supported gameId when asked", async () => {
+    await GET(request("?gameId=penguinRunGame"));
+
+    expect(mocks.find).toHaveBeenCalledWith(expect.objectContaining({ gameId: "penguinRunGame" }));
+  });
+});

--- a/src/app/api/gameData/mine/route.ts
+++ b/src/app/api/gameData/mine/route.ts
@@ -1,0 +1,65 @@
+import connectDB from "@/database/db";
+import GameData from "@/database/gameDataSchema";
+import { getRequestActor } from "@/lib/server/apiAuthorization";
+import { resolveClassroomOwnerKeys, resolveDataPrincipal } from "@/lib/server/classroomAuthorization";
+import { NextRequest, NextResponse } from "next/server";
+
+const SUPPORTED_GAME_IDS = ["statesOfMatterGame", "penguinRunGame"];
+
+/**
+ * The caller's own saves, newest first.
+ *
+ * Distinct from `GET /api/gameData`, which is an administrator-wide listing. This returns only the
+ * records the caller already owns, so it needs no additional authorization beyond resolving who they
+ * are. A classroom participant's lineage is included, which is what lets a student who rejoins a
+ * reopened class find the save they made before it — their owner key changed with their new
+ * participant row, but the records did not move.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    await connectDB();
+
+    const principal = await resolveDataPrincipal(request, await getRequestActor());
+    if (!principal.ok) return principal.response;
+    if (!principal.value.ownerId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const ownerIds = principal.value.classroom
+      ? await resolveClassroomOwnerKeys(principal.value.classroom)
+      : [principal.value.ownerId];
+
+    const requestedGameId = request.nextUrl.searchParams.get("gameId");
+    const gameIdFilter =
+      requestedGameId && SUPPORTED_GAME_IDS.includes(requestedGameId) ? requestedGameId : { $in: SUPPORTED_GAME_IDS };
+
+    const saves = await GameData.find({ userId: { $in: ownerIds }, gameId: gameIdFilter })
+      .select("saveId gameId lastUpdated completedLevels completedStageIds")
+      .sort({ lastUpdated: -1 })
+      .lean<
+        Array<{
+          saveId: string;
+          gameId: string;
+          lastUpdated: Date;
+          completedLevels?: number[];
+          completedStageIds?: string[];
+        }>
+      >();
+
+    return NextResponse.json(
+      {
+        saves: saves.map((save) => ({
+          saveId: save.saveId,
+          gameId: save.gameId,
+          lastUpdated: save.lastUpdated,
+          completedLevelCount: save.completedLevels?.length ?? 0,
+          completedStageCount: save.completedStageIds?.length ?? 0,
+        })),
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.error("GET /api/gameData/mine error:", error);
+    return NextResponse.json({ error: "Failed to load game data" }, { status: 500 });
+  }
+}

--- a/src/components/GamePlayer.tsx
+++ b/src/components/GamePlayer.tsx
@@ -104,6 +104,35 @@ export default function GamePlayer({ game, saveId, sessionId, classroomId, userI
     clearClassroomParticipantProvenance();
   }, []);
 
+  // Classroom saves are owned by `participant:<id>`, and that id changes when a student rejoins a
+  // reopened class, so nothing client-side survives to point at the earlier save. Ask the server for
+  // the saves this caller owns — it resolves the participant's lineage within the class — and adopt
+  // the most recent one so progress carries across a reopen instead of restarting.
+  useEffect(() => {
+    if (!activeClassroomSession?.participantId || classroomSaveIdRef.current) return;
+
+    let ignore = false;
+    (async () => {
+      try {
+        const response = await fetch(`/api/gameData/mine?gameId=${encodeURIComponent(game)}`, { cache: "no-store" });
+        if (!response.ok) return;
+
+        const result = (await response.json()) as { saves?: Array<{ saveId?: string }> };
+        const latestSaveId = result.saves?.find((save) => typeof save.saveId === "string")?.saveId;
+        if (ignore || !latestSaveId || classroomSaveIdRef.current) return;
+
+        classroomSaveIdRef.current = latestSaveId;
+        setClassroomSaveId(latestSaveId);
+      } catch {
+        // A failed lookup just means starting a fresh save, which is the previous behaviour.
+      }
+    })();
+
+    return () => {
+      ignore = true;
+    };
+  }, [activeClassroomSession?.participantId, game]);
+
   const classroomSessionId = activeClassroomSession?.sessionId ?? classroomId;
   const classroomParticipantId = activeClassroomSession?.participantId;
   const effectiveSaveId = classroomParticipantId ? classroomSaveId : personalSaveId;

--- a/src/lib/server/classroomAuthorization.test.ts
+++ b/src/lib/server/classroomAuthorization.test.ts
@@ -8,6 +8,7 @@ import {
   createClassroomCredential,
   hashClassroomSecret,
   parseClassroomCredential,
+  resolveClassroomOwnerKeys,
   resolveDataPrincipal,
   resolveDataPrincipalFromCredential,
   setClassroomCredentialCookie,
@@ -179,5 +180,94 @@ describe("classroom participant credentials", () => {
 
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.response.status).toBe(401);
+  });
+});
+
+describe("resolveClassroomOwnerKeys", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  const ROOT = new mongoose.Types.ObjectId();
+  const CONTINUATION = new mongoose.Types.ObjectId();
+  const OLD_PARTICIPANT = new mongoose.Types.ObjectId();
+  const NEW_PARTICIPANT = new mongoose.Types.ObjectId();
+
+  const participant = (sessionId: string, participantId: string) => ({
+    participantId,
+    sessionId,
+    displayName: "Ada",
+    clerkId: "clerk-student",
+  });
+
+  function stubChain(options: { chain: mongoose.Types.ObjectId[]; siblings: mongoose.Types.ObjectId[] }) {
+    vi.spyOn(ClassroomSession, "findOne").mockReturnValue({
+      select: () => ({ lean: async () => ({ _id: CONTINUATION, rootSessionId: ROOT }) }),
+    } as never);
+    vi.spyOn(ClassroomSession, "find").mockReturnValue({
+      select: () => ({ lean: async () => options.chain.map((id) => ({ _id: id })) }),
+    } as never);
+    vi.spyOn(ClassroomParticipant, "findOne").mockReturnValue({
+      select: () => ({ lean: async () => ({ participantKey: "clerk:clerk-student" }) }),
+    } as never);
+    vi.spyOn(ClassroomParticipant, "find").mockReturnValue({
+      select: () => ({ sort: () => ({ lean: async () => options.siblings.map((id) => ({ _id: id })) }) }),
+    } as never);
+  }
+
+  it("includes the student's earlier participant rows in the same class", async () => {
+    stubChain({ chain: [ROOT, CONTINUATION], siblings: [NEW_PARTICIPANT, OLD_PARTICIPANT] });
+
+    const keys = await resolveClassroomOwnerKeys(participant(String(CONTINUATION), String(NEW_PARTICIPANT)));
+
+    // Current key first, so callers that want "most current" can take the head.
+    expect(keys).toEqual([`participant:${NEW_PARTICIPANT}`, `participant:${OLD_PARTICIPANT}`]);
+  });
+
+  it("only matches rows sharing the caller's own participantKey", async () => {
+    stubChain({ chain: [ROOT, CONTINUATION], siblings: [NEW_PARTICIPANT] });
+
+    await resolveClassroomOwnerKeys(participant(String(CONTINUATION), String(NEW_PARTICIPANT)));
+
+    // The key is what scopes this to one student; without it the chain query would return the
+    // whole class roster.
+    expect(ClassroomParticipant.find).toHaveBeenCalledWith(
+      expect.objectContaining({ participantKey: "clerk:clerk-student" }),
+    );
+  });
+
+  it("stays within the class chain rather than searching every session", async () => {
+    stubChain({ chain: [ROOT, CONTINUATION], siblings: [NEW_PARTICIPANT] });
+
+    await resolveClassroomOwnerKeys(participant(String(CONTINUATION), String(NEW_PARTICIPANT)));
+
+    expect(ClassroomSession.find).toHaveBeenCalledWith({ $or: [{ _id: ROOT }, { rootSessionId: ROOT }] });
+    const participantQuery = (ClassroomParticipant.find as unknown as { mock: { calls: unknown[][] } }).mock
+      .calls[0][0];
+    expect(participantQuery).toMatchObject({ sessionId: { $in: [ROOT, CONTINUATION] } });
+  });
+
+  it("returns only the current key for a class that has never been reopened", async () => {
+    stubChain({ chain: [ROOT], siblings: [NEW_PARTICIPANT, OLD_PARTICIPANT] });
+
+    const keys = await resolveClassroomOwnerKeys(participant(String(ROOT), String(NEW_PARTICIPANT)));
+
+    // A single-session chain cannot have lineage, so it short-circuits before querying participants.
+    expect(keys).toEqual([`participant:${NEW_PARTICIPANT}`]);
+    expect(ClassroomParticipant.find).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the current key when the session cannot be found", async () => {
+    vi.spyOn(ClassroomSession, "findOne").mockReturnValue({
+      select: () => ({ lean: async () => null }),
+    } as never);
+
+    const keys = await resolveClassroomOwnerKeys(participant(String(CONTINUATION), String(NEW_PARTICIPANT)));
+
+    expect(keys).toEqual([`participant:${NEW_PARTICIPANT}`]);
+  });
+
+  it("falls back to the current key for a malformed session id", async () => {
+    const keys = await resolveClassroomOwnerKeys(participant("not-an-object-id", String(NEW_PARTICIPANT)));
+
+    expect(keys).toEqual([`participant:${NEW_PARTICIPANT}`]);
   });
 });

--- a/src/lib/server/classroomAuthorization.ts
+++ b/src/lib/server/classroomAuthorization.ts
@@ -198,6 +198,53 @@ export async function resolveDataPrincipal(
   );
 }
 
+/**
+ * Every owner key a student's records may sit under within one class.
+ *
+ * Reopening a class appends a continuation session, and a returning student joins it as a *new*
+ * participant row — same `participantKey`, new `_id`. Records are owned by `participant:<_id>`, so
+ * without this a student who returns after a reopen cannot reach anything they did before it.
+ *
+ * Scoped two ways so it cannot widen access: only rows sharing the authorized participant's exact
+ * `participantKey`, and only within the same continuation chain. The authorized participant's own
+ * key is always first, so callers that want "most current" can take the head.
+ */
+export async function resolveClassroomOwnerKeys(participant: AuthorizedClassroomParticipant): Promise<string[]> {
+  const current = `participant:${participant.participantId}`;
+
+  if (!mongoose.Types.ObjectId.isValid(participant.sessionId)) return [current];
+
+  const session = await ClassroomSession.findOne({ _id: participant.sessionId })
+    .select("rootSessionId")
+    .lean<{ _id: mongoose.Types.ObjectId; rootSessionId?: mongoose.Types.ObjectId | null } | null>();
+  if (!session) return [current];
+
+  const rootId = session.rootSessionId ?? session._id;
+  const chainSessionIds = await ClassroomSession.find({
+    $or: [{ _id: rootId }, { rootSessionId: rootId }],
+  })
+    .select("_id")
+    .lean<Array<{ _id: mongoose.Types.ObjectId }>>();
+
+  if (chainSessionIds.length <= 1) return [current];
+
+  const self = await ClassroomParticipant.findOne({ _id: participant.participantId })
+    .select("participantKey")
+    .lean<{ participantKey: string } | null>();
+  if (!self?.participantKey) return [current];
+
+  const siblings = await ClassroomParticipant.find({
+    sessionId: { $in: chainSessionIds.map((entry) => entry._id) },
+    participantKey: self.participantKey,
+  })
+    .select("_id")
+    .sort({ joinedAt: -1 })
+    .lean<Array<{ _id: mongoose.Types.ObjectId }>>();
+
+  const keys = siblings.map((entry) => `participant:${String(entry._id)}`);
+  return [current, ...keys.filter((key) => key !== current)];
+}
+
 export async function canEducatorReadClassroom(actor: RequestActor, classroomSessionId: string | null | undefined) {
   if (!actor.userId || !classroomSessionId || !mongoose.Types.ObjectId.isValid(classroomSessionId)) return false;
   if (actor.role === "admin") return true;

--- a/src/lib/server/quizProgress.test.ts
+++ b/src/lib/server/quizProgress.test.ts
@@ -4,25 +4,26 @@ import type { RequestActor } from "@/lib/server/apiAuthorization";
 
 const mocks = vi.hoisted(() => ({
   connectDB: vi.fn(),
-  findOne: vi.fn(),
+  find: vi.fn(),
+  resolveClassroomOwnerKeys: vi.fn(),
   resolveDataPrincipalFromCredential: vi.fn(),
 }));
 
 vi.mock("@/database/db", () => ({ default: mocks.connectDB }));
-vi.mock("@/database/quizSchema", () => ({ default: { findOne: mocks.findOne } }));
+vi.mock("@/database/quizSchema", () => ({ default: { find: mocks.find } }));
 vi.mock("@/lib/server/classroomAuthorization", () => ({
   resolveDataPrincipalFromCredential: mocks.resolveDataPrincipalFromCredential,
+  resolveClassroomOwnerKeys: mocks.resolveClassroomOwnerKeys,
 }));
 
 import { getPreviousQuizScore } from "@/lib/server/quizProgress";
 
 const actor: RequestActor = { userId: "clerk-student", role: "player" };
 
-/** Answers `Quiz.findOne` per owner key, so a test can give the personal and participant records different scores. */
-function stubQuizzesByOwner(byOwner: Record<string, unknown>) {
-  mocks.findOne.mockImplementation((filter: { clerkId: string }) => ({
-    lean: vi.fn().mockResolvedValue(byOwner[filter.clerkId] ?? null),
-  }));
+/** Answers `Quiz.find` with one row per owner key, so a test can give different owners different scores. */
+function stubQuizzesByOwner(byOwner: Record<string, Record<string, number>>) {
+  const rows = Object.entries(byOwner).map(([clerkId, scores]) => ({ clerkId, ...scores }));
+  mocks.find.mockReturnValue({ select: () => ({ lean: vi.fn().mockResolvedValue(rows) }) });
 }
 
 describe("getPreviousQuizScore", () => {
@@ -32,6 +33,9 @@ describe("getPreviousQuizScore", () => {
       ok: true,
       value: { ownerId: "clerk-student", actor, classroom: null },
     });
+    mocks.resolveClassroomOwnerKeys.mockImplementation(async (classroom: { participantId: string }) => [
+      `participant:${classroom.participantId}`,
+    ]);
     stubQuizzesByOwner({ "clerk-student": { penguinRunScoreBefore: 1, statesOfMatterScoreBefore: 2 } });
   });
 
@@ -39,7 +43,7 @@ describe("getPreviousQuizScore", () => {
     await expect(getPreviousQuizScore("penguinRunQuiz", actor)).resolves.toBe(1);
 
     expect(mocks.resolveDataPrincipalFromCredential).toHaveBeenCalledWith(undefined, actor, undefined);
-    expect(mocks.findOne).toHaveBeenCalledWith({ clerkId: "clerk-student" });
+    expect(mocks.find).toHaveBeenCalledWith({ clerkId: { $in: ["clerk-student"] } });
   });
 
   it("opens the database connection before resolving the principal", async () => {
@@ -73,7 +77,7 @@ describe("getPreviousQuizScore", () => {
     await expect(getPreviousQuizScore("statesOfMatterQuiz", classroomActor, "opaque-cookie")).resolves.toBe(2);
 
     expect(mocks.resolveDataPrincipalFromCredential).toHaveBeenCalledWith("opaque-cookie", classroomActor, undefined);
-    expect(mocks.findOne).toHaveBeenCalledWith({ clerkId: "participant:participant-1" });
+    expect(mocks.find).toHaveBeenCalledWith({ clerkId: { $in: ["participant:participant-1"] } });
   });
 
   it("returns no score without querying quiz data when the credential is unauthorized", async () => {
@@ -85,7 +89,7 @@ describe("getPreviousQuizScore", () => {
     await expect(getPreviousQuizScore("penguinRunQuiz", { userId: null, role: null }, "expired-cookie")).resolves.toBe(
       -1,
     );
-    expect(mocks.findOne).not.toHaveBeenCalled();
+    expect(mocks.find).not.toHaveBeenCalled();
   });
 
   it("degrades to no previous score instead of failing the page when the principal cannot be resolved", async () => {
@@ -112,7 +116,7 @@ describe("getPreviousQuizScore", () => {
 
     // The claim is validated by the same path the write uses, not trusted on its own.
     expect(mocks.resolveDataPrincipalFromCredential).toHaveBeenCalledWith(undefined, actor, "participant-7");
-    expect(mocks.findOne).toHaveBeenCalledWith({ clerkId: "participant:participant-7" });
+    expect(mocks.find).toHaveBeenCalledWith({ clerkId: { $in: ["participant:participant-7"] } });
   });
 
   it("returns no score when a carried participant fails authorization", async () => {
@@ -123,7 +127,7 @@ describe("getPreviousQuizScore", () => {
     });
 
     await expect(getPreviousQuizScore("statesOfMatterQuiz", actor, undefined, "someone-elses-id")).resolves.toBe(-1);
-    expect(mocks.findOne).not.toHaveBeenCalled();
+    expect(mocks.find).not.toHaveBeenCalled();
   });
 
   it("still resolves from the cookie alone when no participant is carried", async () => {
@@ -132,9 +136,63 @@ describe("getPreviousQuizScore", () => {
     expect(mocks.resolveDataPrincipalFromCredential).toHaveBeenCalledWith("opaque-cookie", actor, undefined);
   });
 
+  it("finds a baseline recorded before the class was reopened", async () => {
+    const classroom = { participantId: "participant-new", sessionId: "s2", displayName: "Ada", clerkId: null };
+    mocks.resolveDataPrincipalFromCredential.mockResolvedValue({
+      ok: true,
+      value: { ownerId: "participant:participant-new", actor, classroom },
+    });
+    // Rejoining a reopened class produces a new participant row, so the baseline sits under the
+    // earlier key while the new row has nothing yet.
+    mocks.resolveClassroomOwnerKeys.mockResolvedValue(["participant:participant-new", "participant:participant-old"]);
+    stubQuizzesByOwner({ "participant:participant-old": { statesOfMatterScoreBefore: 2 } });
+
+    await expect(getPreviousQuizScore("statesOfMatterQuiz", actor, "cookie")).resolves.toBe(2);
+    expect(mocks.find).toHaveBeenCalledWith({
+      clerkId: { $in: ["participant:participant-new", "participant:participant-old"] },
+    });
+  });
+
+  it("prefers the current participant's score over an earlier one", async () => {
+    const classroom = { participantId: "participant-new", sessionId: "s2", displayName: "Ada", clerkId: null };
+    mocks.resolveDataPrincipalFromCredential.mockResolvedValue({
+      ok: true,
+      value: { ownerId: "participant:participant-new", actor, classroom },
+    });
+    mocks.resolveClassroomOwnerKeys.mockResolvedValue(["participant:participant-new", "participant:participant-old"]);
+    stubQuizzesByOwner({
+      "participant:participant-new": { statesOfMatterScoreBefore: 1 },
+      "participant:participant-old": { statesOfMatterScoreBefore: 3 },
+    });
+
+    // Lineage is a fallback, not a merge: a baseline retaken in the reopened class wins.
+    await expect(getPreviousQuizScore("statesOfMatterQuiz", actor, "cookie")).resolves.toBe(1);
+  });
+
+  it("skips an unattempted earlier score rather than returning -1 from it", async () => {
+    const classroom = { participantId: "participant-new", sessionId: "s2", displayName: "Ada", clerkId: null };
+    mocks.resolveDataPrincipalFromCredential.mockResolvedValue({
+      ok: true,
+      value: { ownerId: "participant:participant-new", actor, classroom },
+    });
+    mocks.resolveClassroomOwnerKeys.mockResolvedValue(["participant:participant-new", "participant:participant-old"]);
+    stubQuizzesByOwner({
+      "participant:participant-new": { statesOfMatterScoreBefore: -1 },
+      "participant:participant-old": { statesOfMatterScoreBefore: 3 },
+    });
+
+    await expect(getPreviousQuizScore("statesOfMatterQuiz", actor, "cookie")).resolves.toBe(3);
+  });
+
+  it("does not resolve lineage for a personal player", async () => {
+    await getPreviousQuizScore("penguinRunQuiz", actor);
+
+    expect(mocks.resolveClassroomOwnerKeys).not.toHaveBeenCalled();
+  });
+
   it("degrades to no previous score when the quiz lookup itself fails", async () => {
     // Covers the second await inside the try block, not just the first.
-    mocks.findOne.mockReturnValue({ lean: vi.fn().mockRejectedValue(new Error("read timeout")) });
+    mocks.find.mockReturnValue({ select: () => ({ lean: vi.fn().mockRejectedValue(new Error("read timeout")) }) });
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
 
     await expect(getPreviousQuizScore("penguinRunQuiz", actor)).resolves.toBe(-1);

--- a/src/lib/server/quizProgress.ts
+++ b/src/lib/server/quizProgress.ts
@@ -1,7 +1,7 @@
 import connectDB from "@/database/db";
 import Quiz from "@/database/quizSchema";
 import { RequestActor } from "@/lib/server/apiAuthorization";
-import { resolveDataPrincipalFromCredential } from "@/lib/server/classroomAuthorization";
+import { resolveClassroomOwnerKeys, resolveDataPrincipalFromCredential } from "@/lib/server/classroomAuthorization";
 
 type QuizKey = "penguinRunQuiz" | "statesOfMatterQuiz";
 
@@ -40,10 +40,23 @@ export async function getPreviousQuizScore(
     const principal = await resolveDataPrincipalFromCredential(classroomCredential, actor, claimedParticipantId);
     if (!principal.ok || !principal.value.ownerId) return -1;
 
-    const quiz = await Quiz.findOne({ clerkId: principal.value.ownerId }).lean<QuizBeforeScores | null>();
-    const score = quiz?.[getBeforeScoreField(quizKey)];
+    // A student who rejoins a reopened class gets a new participant row, so their baseline sits
+    // under an earlier owner key. Search the lineage, newest first, and take the first real score.
+    const ownerIds = principal.value.classroom
+      ? await resolveClassroomOwnerKeys(principal.value.classroom)
+      : [principal.value.ownerId];
 
-    return typeof score === "number" ? score : -1;
+    const quizzes = await Quiz.find({ clerkId: { $in: ownerIds } })
+      .select("clerkId penguinRunScoreBefore statesOfMatterScoreBefore")
+      .lean<Array<QuizBeforeScores & { clerkId: string }>>();
+
+    const field = getBeforeScoreField(quizKey);
+    for (const ownerId of ownerIds) {
+      const score = quizzes.find((quiz) => quiz.clerkId === ownerId)?.[field];
+      if (typeof score === "number" && score >= 0) return score;
+    }
+
+    return -1;
   } catch (error) {
     // "No previous score" is a state the quiz already renders. Letting a transient database error
     // escape would fail the whole server-rendered page instead.


### PR DESCRIPTION
Closes #58.

## Problem

Reopening a class appends a continuation session, and a returning student joins it as a **new** `ClassroomParticipant` row — same `participantKey`, new `_id`. Records are owned by `participant:<_id>`, so the student's own saves and quiz baseline became unreachable the moment the class reopened. The educator's view was always correct; this was the student's side only.

## The primitive

`resolveClassroomOwnerKeys` returns every owner key a student's records may sit under within one class. It is scoped two ways so it cannot widen access:

- only participant rows sharing the caller's **exact `participantKey`** — without this the chain query would return the whole roster;
- only within the **same continuation chain**.

The caller's current key is always first, so a caller wanting "most current" takes the head. A class that has never been reopened short-circuits before querying participants at all.

## Quiz baseline

`getPreviousQuizScore` now searches the lineage, newest key first, and takes the first real score. This is a **fallback, not a merge**: a baseline retaken in the reopened class still wins, and an unattempted `-1` on the newer row is skipped rather than returned.

## Game saves

This turned out to be broader than the issue described. `classroomSaveId` lived only in component state, which starts empty on every page load — so a classroom student never resumed a save **even without a reopen**. There was no server-side way to find it either, since `GET /api/gameData` is an administrator listing.

`GET /api/gameData/mine` returns the caller's own saves, across their lineage, and the player adopts the most recent on mount. It is deliberately a separate route rather than a self-scope bolted onto the admin listing.

## Tests

Coverage includes: earlier participant rows included; only rows matching the caller's `participantKey`; the query staying inside the chain; a never-reopened class short-circuiting; fallbacks for a missing session and a malformed session id. For the baseline: found after a reopen, current score preferred over an earlier one, unattempted earlier score skipped, and no lineage resolution for personal players. For the route: principal rejection, anonymous callers, lineage used for classroom callers, personal callers using only their own key, and an unsupported `gameId` ignored rather than filtered on.

## Verification

- `npm test -- --run` — 106 passed
- `npm run lint` — 0 errors
- `npx tsc --noEmit` — clean across `src/`
- `next build` — compiles, route registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)