### PR TITLE
Add health checks, structured error reporting, and an operations runbook

### DIFF
--- a/docs/api-authorization.md
+++ b/docs/api-authorization.md
@@ -19,6 +19,7 @@ Classroom records are keyed to the authorized participant, including for signed-
 | `/api/admin/:id/role`                             | PATCH            | Administrator                                                  |
 | `/api/admin/analytics`                            | GET              | Administrator                                                  |
 | `/api/auth/admin-access`                          | GET              | Administrator                                                  |
+| `/api/health`                                     | GET              | Public; deployment health only, carries no learner data        |
 | `/api/classroom-sessions`                         | GET, POST, PATCH | Signed-in educator; sessions are teacher-scoped                |
 | `/api/classroom-sessions/join`                    | POST             | Public with an active access code; issues classroom credential |
 | `/api/classroom-sessions/history`                 | GET              | Signed-in educator; only their own classes                     |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,158 @@
+# Operations Runbook
+
+For whoever is on the hook when something breaks — including people who did not build this.
+
+## System shape
+
+| Piece          | Where it lives                                           | Notes                                                         |
+| -------------- | -------------------------------------------------------- | ------------------------------------------------------------- |
+| Website        | Vercel, deployed from `develop`                          | Every merge to `develop` goes straight to production          |
+| Database       | MongoDB Atlas, via `MONGO_URI`                           | Holds learner records: saves, quiz results, classroom rosters |
+| Authentication | Clerk                                                    | Route protection runs in middleware (`src/proxy.ts`)          |
+| Games          | Unity WebGL builds committed under `public/game/<Game>/` | Served as static assets from the website                      |
+
+## Health check
+
+`GET /api/health` — unauthenticated, carries no learner data.
+
+```sh
+curl -s https://<site>/api/health | jq
+```
+
+Returns `200` when healthy and `503` otherwise, so an uptime monitor can alert without parsing the
+body. It reports:
+
+- **database** — connection ready state. `degraded` means queries would buffer and eventually time
+  out, which presents as a hang rather than an error.
+- **games** — for each embedded build, whether `index.html`, `_source_sha.txt`, and `_build_id.txt`
+  are present, plus the source SHA, build id, and build time. A missing file means the artifact was
+  promoted incompletely, which otherwise only shows up as a blank canvas for a child.
+- **release** — the deploying commit, so you can tell exactly what is live.
+
+Point an uptime monitor at this every 5 minutes.
+
+## Alerts worth configuring
+
+| Signal                            | Threshold              | Why it matters                           | First response                  |
+| --------------------------------- | ---------------------- | ---------------------------------------- | ------------------------------- |
+| `/api/health` non-200             | 2 consecutive failures | Site or database is down                 | Check Vercel status, then Atlas |
+| `scope: "database"` errors        | Any in 5 minutes       | Learner records are not being written    | Check Atlas connection limits   |
+| `scope: "progress-save"` errors   | >5 in 15 minutes       | Children are losing game progress        | Check API logs and Atlas        |
+| `scope: "quiz-save"` errors       | >3 in 15 minutes       | Learning outcomes are not being recorded | Same                            |
+| `scope: "unity-boot"` errors      | >5 in 15 minutes       | A game build is broken for everyone      | Roll back the game artifact     |
+| Vercel build failure on `develop` | Any                    | Production deploy blocked                | See rollback below              |
+
+Ownership: assign one named person per alert before launch. An alert with no owner is not an alert.
+
+## Error reports
+
+Errors are written as single-line JSON via `reportError` in `src/lib/server/observability.ts`:
+
+```json
+{
+  "level": "error",
+  "scope": "progress-save",
+  "event": "save-failed",
+  "correlationId": "…",
+  "environment": "production",
+  "release": "abc123",
+  "message": "…",
+  "context": { "gameId": "PenguinRun" }
+}
+```
+
+Two properties are deliberate and should be preserved:
+
+- **Context is primitives only.** Objects and arrays are dropped rather than serialized, so a quiz
+  answer, a child's name, or a whole request body cannot be attached by accident.
+- **Scopes are distinguishable.** A WebGL boot failure and a save failure need different responses,
+  so they must be separable in an alert query.
+
+### Adding a hosted error tracker
+
+`setErrorSink` in the same module is the seam. Wire it once at startup and every existing call site
+begins reporting there with no other change:
+
+```ts
+setErrorSink((report) => Sentry.captureMessage(report.message, { extra: report }));
+```
+
+Choose a tool with a data-processing agreement appropriate for a product used by children, and
+confirm it does not capture request bodies or session replay by default.
+
+## Rollback
+
+### The website
+
+Fastest path is Vercel's instant rollback: **Deployments → pick the last known-good → Promote to
+Production**. This re-serves a previous build without a git operation and takes effect immediately.
+
+To roll back in git instead — which is what you want if the bad change must not come back on the
+next deploy:
+
+```sh
+git switch develop
+git pull --ff-only
+git revert -m 1 <merge-commit-sha>    # -m 1 for a merge commit
+git push
+```
+
+Confirm afterwards with `curl -s https://<site>/api/health | jq .release`.
+
+### A game build
+
+Game artifacts are committed to this repository, so a bad build is reverted like any other change.
+Identify the live build first:
+
+```sh
+curl -s https://<site>/api/health | jq '.checks.games'
+```
+
+Then revert the commit that promoted it, and re-check that `sourceSha` moved back.
+
+## Database backup and restore
+
+MongoDB Atlas takes the backups; this repository holds no copy of learner data.
+
+**Before launch, confirm and record here:**
+
+- [ ] Atlas backup is enabled on the production cluster
+- [ ] Retention period: \_\_\_\_ days
+- [ ] Point-in-time restore available: yes / no
+- [ ] Who can perform a restore: \_\_\_\_
+
+**Restore drill — run this once before launch, and record the date.** An untested backup is not a
+backup.
+
+1. In Atlas, choose **Backup → Restore** and target a **new** cluster, never production.
+2. Point a local checkout at it: `MONGO_URI=<restored-cluster-uri> npm run dev`.
+3. Verify an educator can open a class in Class History and see its roster and quiz results.
+4. Delete the temporary cluster.
+5. Record the drill date and who ran it: \_\_\_\_
+
+Restoring over production is a last resort: it discards everything written since the snapshot,
+including a class currently in session.
+
+## Incident triage
+
+1. **Check `/api/health`.** It separates a database problem from a broken game build in one request.
+2. **Check Vercel** for a failed or in-progress deploy on `develop`.
+3. **Search logs by `correlationId`** to follow one incident across reports; filter by `scope` to
+   identify the subsystem.
+4. **Decide: roll back or fix forward.** During a live class, roll back — an educator with thirty
+   children waiting cannot absorb a fix-forward cycle.
+5. **Record what happened** and, if the cause was not visible from the health check or logs, add the
+   signal that would have made it visible.
+
+## Known operational characteristics
+
+- **`develop` is production.** There is no staging branch or release gate; a merge deploys. Treat
+  every merge to `develop` as a production change.
+- **Classroom sessions expire after 8 hours.** An educator reporting that "the code stopped working"
+  is usually an expired session, not an outage. They can reopen the class from Class History, which
+  issues a new code.
+- **A reopened class retires every previous access code.** A student holding an old code cannot
+  rejoin, by design.
+- **`ClassroomSession` relies on a unique partial index** to guarantee one live continuation per
+  class. It builds in the background on first connect, and a failure is logged as
+  `ClassroomSession index build failed`. If a class ever shows two live sessions, check that first.

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,95 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import mongoose from "mongoose";
+import { NextResponse } from "next/server";
+import connectDB from "@/database/db";
+import { currentRelease, reportError } from "@/lib/server/observability";
+
+export const dynamic = "force-dynamic";
+
+const GAMES = ["StatesOfMatter", "PenguinRun"] as const;
+
+// Present in every promoted Unity build. Their absence means the artifact was copied incompletely,
+// which otherwise only shows up as a blank canvas for a child.
+const REQUIRED_BUILD_FILES = ["index.html", "_source_sha.txt", "_build_id.txt"];
+
+type CheckStatus = "ok" | "degraded" | "down";
+
+type GameCheck = {
+  game: string;
+  status: CheckStatus;
+  sourceSha: string | null;
+  buildId: string | null;
+  builtAtUtc: string | null;
+  missingFiles: string[];
+};
+
+async function readMarker(game: string, file: string) {
+  try {
+    const contents = await readFile(path.join(process.cwd(), "public", "game", game, file), "utf8");
+    return contents.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+async function checkGame(game: string): Promise<GameCheck> {
+  const present = await Promise.all(
+    REQUIRED_BUILD_FILES.map(async (file) => ({ file, found: (await readMarker(game, file)) !== null })),
+  );
+  const missingFiles = present.filter((entry) => !entry.found).map((entry) => entry.file);
+
+  const [sourceSha, buildId, builtAtUtc] = await Promise.all([
+    readMarker(game, "_source_sha.txt"),
+    readMarker(game, "_build_id.txt"),
+    readMarker(game, "_built_at_utc.txt"),
+  ]);
+
+  return {
+    game,
+    status: missingFiles.length === 0 ? "ok" : "down",
+    sourceSha,
+    buildId,
+    builtAtUtc,
+    missingFiles,
+  };
+}
+
+async function checkDatabase(): Promise<{ status: CheckStatus; readyState: number }> {
+  try {
+    await connectDB();
+    // 1 is "connected". Anything else means queries would buffer and eventually time out, which is
+    // the failure mode that looks like a hang rather than an error.
+    const readyState = mongoose.connection.readyState;
+    return { status: readyState === 1 ? "ok" : "degraded", readyState };
+  } catch (error) {
+    reportError({ scope: "database", event: "health-check-failed", error });
+    return { status: "down", readyState: mongoose.connection?.readyState ?? 0 };
+  }
+}
+
+/**
+ * Deployment health for the website and both embedded game builds.
+ *
+ * Deliberately unauthenticated and free of any learner data: it reports only build provenance and
+ * connectivity, so it can be polled by an uptime monitor. The game source SHAs make it possible to
+ * confirm which Unity revision is actually live, which is what a rollback needs to verify.
+ */
+export async function GET() {
+  const [database, games] = await Promise.all([checkDatabase(), Promise.all(GAMES.map(checkGame))]);
+
+  const statuses: CheckStatus[] = [database.status, ...games.map((game) => game.status)];
+  const status: CheckStatus = statuses.includes("down") ? "down" : statuses.includes("degraded") ? "degraded" : "ok";
+
+  return NextResponse.json(
+    {
+      status,
+      release: currentRelease(),
+      environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "development",
+      checkedAt: new Date().toISOString(),
+      checks: { database, games },
+    },
+    // Non-2xx on failure so an uptime monitor alerts without needing to parse the body.
+    { status: status === "ok" ? 200 : 503 },
+  );
+}

--- a/src/lib/server/observability.test.ts
+++ b/src/lib/server/observability.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { reportError, setErrorSink } from "@/lib/server/observability";
+
+describe("reportError", () => {
+  afterEach(() => {
+    setErrorSink(null);
+    vi.restoreAllMocks();
+  });
+
+  it("never carries object-shaped context, so a request body cannot be attached by accident", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const report = reportError({
+      scope: "quiz-save",
+      event: "save-failed",
+      error: new Error("boom"),
+      context: {
+        quizId: "quiz-1",
+        attempt: 2,
+        retried: true,
+        empty: null,
+        // All of the below are the shapes that would leak a child's data.
+        answers: [{ questionId: "q1", selectedAnswer: "Solid" }],
+        student: { name: "Ada", clerkId: "user_2abc" },
+        requestBody: { statesOfMatterQuestionResults: [] },
+      },
+    });
+
+    expect(report.context).toEqual({ quizId: "quiz-1", attempt: 2, retried: true, empty: null });
+    const serialized = JSON.stringify(report);
+    expect(serialized).not.toContain("Solid");
+    expect(serialized).not.toContain("Ada");
+    expect(serialized).not.toContain("user_2abc");
+  });
+
+  it("distinguishes a WebGL boot failure from a save failure", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const boot = reportError({ scope: "unity-boot", event: "load-failed", error: new Error("no wasm") });
+    const save = reportError({ scope: "progress-save", event: "save-failed", error: new Error("503") });
+
+    // An alert has to be able to tell these apart; they need different responses.
+    expect(boot.scope).not.toBe(save.scope);
+    expect(boot.correlationId).not.toBe(save.correlationId);
+  });
+
+  it("stamps the environment and release so an alert identifies what is broken", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubEnv("VERCEL_ENV", "production");
+    vi.stubEnv("VERCEL_GIT_COMMIT_SHA", "abc123");
+
+    const report = reportError({ scope: "api", event: "unhandled", error: new Error("boom") });
+
+    expect(report).toMatchObject({ environment: "production", release: "abc123" });
+    vi.unstubAllEnvs();
+  });
+
+  it("emits one parseable JSON line per report", () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    reportError({ scope: "api", event: "unhandled", error: new Error("boom") });
+
+    const line = consoleError.mock.calls[0][0] as string;
+    expect(() => JSON.parse(line)).not.toThrow();
+    expect(JSON.parse(line)).toMatchObject({ level: "error", scope: "api", event: "unhandled" });
+  });
+
+  it("forwards to a configured sink and survives one that throws", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const sink = vi.fn(() => {
+      throw new Error("tracker unreachable");
+    });
+    setErrorSink(sink);
+
+    // A failing error tracker must not become a second outage.
+    expect(() => reportError({ scope: "api", event: "unhandled", error: new Error("boom") })).not.toThrow();
+    expect(sink).toHaveBeenCalledTimes(1);
+  });
+
+  it("accepts a caller-supplied correlation id so one incident can be traced across reports", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const first = reportError({ scope: "api", event: "a", error: new Error("x"), correlationId: "corr-1" });
+    const second = reportError({ scope: "progress-save", event: "b", error: new Error("y"), correlationId: "corr-1" });
+
+    expect(first.correlationId).toBe("corr-1");
+    expect(second.correlationId).toBe("corr-1");
+  });
+});

--- a/src/lib/server/observability.ts
+++ b/src/lib/server/observability.ts
@@ -1,0 +1,111 @@
+import { randomUUID } from "node:crypto";
+
+/**
+ * Structured error reporting.
+ *
+ * Two constraints shape this. First, the product serves children, so a report must never carry
+ * quiz answers, names, tokens, or raw request bodies — only identifiers that are already opaque.
+ * Second, KFI will operate this without the team that built it, so a report has to say *which*
+ * environment, release, and subsystem failed, not just that something did.
+ *
+ * `report` writes structured JSON to the server log, which Vercel already collects and which any
+ * log drain can forward. `setErrorSink` is the seam for a hosted error tracker: wire it once in
+ * instrumentation and every existing call site starts reporting there, with no other changes.
+ */
+
+export type ErrorScope =
+  | "api"
+  | "page"
+  | "database"
+  | "unity-boot"
+  | "unity-bridge"
+  | "progress-save"
+  | "quiz-save"
+  | "classroom";
+
+export type ErrorReport = {
+  scope: ErrorScope;
+  event: string;
+  correlationId: string;
+  environment: string;
+  release: string | null;
+  message: string;
+  stack?: string;
+  context: Record<string, string | number | boolean | null>;
+  occurredAt: string;
+};
+
+type ErrorSink = (report: ErrorReport) => void;
+
+let sink: ErrorSink | null = null;
+
+export function setErrorSink(next: ErrorSink | null) {
+  sink = next;
+}
+
+export function newCorrelationId() {
+  return randomUUID();
+}
+
+/**
+ * Vercel exposes the deploying commit here, which is what makes an alert actionable: it identifies
+ * the exact release rather than "production".
+ */
+export function currentRelease() {
+  return process.env.VERCEL_GIT_COMMIT_SHA ?? process.env.NEXT_PUBLIC_RELEASE_SHA ?? null;
+}
+
+function currentEnvironment() {
+  return process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? "development";
+}
+
+/**
+ * Context values are restricted to primitives and are expected to be non-identifying: ids that are
+ * already opaque, counts, route names. Anything object-shaped is dropped rather than serialized,
+ * so a whole request body cannot be attached by accident.
+ */
+function sanitizeContext(context: Record<string, unknown> = {}): ErrorReport["context"] {
+  const safe: ErrorReport["context"] = {};
+
+  for (const [key, value] of Object.entries(context)) {
+    if (value === null) {
+      safe[key] = null;
+    } else if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+      safe[key] = value;
+    }
+  }
+
+  return safe;
+}
+
+export function reportError(input: {
+  scope: ErrorScope;
+  event: string;
+  error: unknown;
+  correlationId?: string;
+  context?: Record<string, unknown>;
+}): ErrorReport {
+  const error = input.error;
+  const report: ErrorReport = {
+    scope: input.scope,
+    event: input.event,
+    correlationId: input.correlationId ?? newCorrelationId(),
+    environment: currentEnvironment(),
+    release: currentRelease(),
+    message: error instanceof Error ? error.message : String(error),
+    ...(error instanceof Error && error.stack ? { stack: error.stack } : {}),
+    context: sanitizeContext(input.context),
+    occurredAt: new Date().toISOString(),
+  };
+
+  // Structured single-line JSON so a log drain can parse and alert on it without regex archaeology.
+  console.error(JSON.stringify({ level: "error", ...report }));
+
+  try {
+    sink?.(report);
+  } catch (sinkError) {
+    console.error("Error sink threw:", sinkError);
+  }
+
+  return report;
+}


### PR DESCRIPTION
Advances #49.

## Why

Nothing in the deployed system could tell a database outage apart from a broken game build, and there was no written recovery expectation for learner records. KFI will operate this without the team that built it.

## `GET /api/health`

Unauthenticated, carries no learner data, answers `503` on failure so an uptime monitor alerts without parsing the body.

- **database** — connection ready state. `degraded` catches the case where queries buffer and time out, which presents as a hang rather than an error. That is the same failure mode behind the `connectDB` bug found on #56.
- **games** — per build, whether `index.html`, `_source_sha.txt`, and `_build_id.txt` are present, plus source SHA, build id, and build time. A missing file means an incompletely promoted artifact, which otherwise surfaces only as a blank canvas for a child.
- **release** — the deploying commit, so a rollback can be *verified* rather than assumed.

## Structured error reporting

`reportError` writes one parseable JSON line with a correlation id, environment, and release. Two properties are deliberate and tested:

- **Context accepts only primitives.** Objects and arrays are dropped rather than serialized, so a quiz answer, a child's name, or a whole request body cannot be attached by accident. There is a test asserting a known answer string, name, and Clerk id never appear in a serialized report.
- **Scopes stay distinguishable.** `unity-boot` and `progress-save` need different responses, so an alert query must separate them.

`setErrorSink` is the seam for a hosted tracker — wire it once and every call site reports there. A sink that throws is caught, because a failing error tracker must not become a second outage.

I deliberately did **not** pick a vendor. That is a decision with a cost and a data-processing agreement attached, for a product used by children, and it should be KFI's call. The runbook says what to look for when choosing.

## `docs/operations.md`

Written for whoever is on call, including someone who did not build this: alert thresholds each with a first response, both rollback paths (Vercel instant rollback and a git revert, with when to prefer each), incident triage, and known operational characteristics — including that `develop` *is* production, and that an educator reporting "the code stopped working" is usually an 8-hour session expiry rather than an outage.

## What is left open on #49

The backup section is a **checklist, not a claim**. Atlas retention and restore capability cannot be verified from this repository, and an untested backup is not a backup. The restore drill is written as a runnable procedure against a temporary cluster, with blanks for the date and owner. Someone with Atlas access has to run it before launch.

Alert *ownership* is likewise left blank — an alert with no named owner is not an alert.

## Verification

- `npm test -- --run` — 128 passed (6 new)
- `npm run lint` — 0 errors
- `npx tsc --noEmit` — clean across `src/`
- `next build` — compiles, `/api/health` registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)