### PR TITLE
Automate Unity WebGL promotion into an auditable pull request

### DIFF
--- a/.github/workflows/build-unity-webgl.yml
+++ b/.github/workflows/build-unity-webgl.yml
@@ -17,10 +17,17 @@ on:
         required: true
         default: main
         type: string
+      promote:
+        description: Open a website pull request with the built artifact
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: read
 
+# One release per game at a time. Two concurrent promotions of the same game would race on the same
+# branch and could interleave two different builds into one pull request.
 concurrency:
   group: unity-webgl-${{ inputs.game }}
   cancel-in-progress: false
@@ -33,6 +40,11 @@ jobs:
 
     env:
       SOURCE_REPOSITORY: ${{ inputs.game == 'penguin-run' && 'hack4impact-calpoly/kids-first-initiative-penguin-run' || 'hack4impact-calpoly/kids-first-initiative-states-of-matter' }}
+
+    outputs:
+      source_sha: ${{ steps.source.outputs.sha }}
+      source_short_sha: ${{ steps.source.outputs.short_sha }}
+      unity_version: ${{ steps.source.outputs.unity_version }}
 
     steps:
       - name: Checkout Unity source
@@ -156,3 +168,87 @@ jobs:
           path: ${{ runner.temp }}/webgl-build
           if-no-files-found: error
           retention-days: 7
+
+  promote:
+    name: Open website pull request
+    if: ${{ inputs.promote }}
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    # Scoped to exactly what promotion needs: push a branch and open a pull request. It deliberately
+    # cannot merge, deploy, or touch production directly — a human approves the pull request.
+    permissions:
+      contents: write
+      pull-requests: write
+
+    env:
+      GAME_DIR: ${{ inputs.game == 'penguin-run' && 'PenguinRun' || 'StatesOfMatter' }}
+      SOURCE_REPOSITORY: ${{ inputs.game == 'penguin-run' && 'hack4impact-calpoly/kids-first-initiative-penguin-run' || 'hack4impact-calpoly/kids-first-initiative-states-of-matter' }}
+      SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
+      SOURCE_SHORT_SHA: ${{ needs.build.outputs.source_short_sha }}
+      UNITY_VERSION: ${{ needs.build.outputs.unity_version }}
+
+    steps:
+      - name: Checkout website
+        uses: actions/checkout@v4
+
+      - name: Download WebGL artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: webgl-${{ inputs.game }}-${{ needs.build.outputs.source_short_sha }}
+          path: incoming-build
+
+      - name: Replace the embedded build
+        shell: bash
+        run: |
+          set -euo pipefail
+          target="public/game/${GAME_DIR}"
+          rm -rf "$target"
+          mkdir -p "$target"
+          cp -R incoming-build/. "$target"/
+          rm -rf incoming-build
+
+      - name: Validate the promoted build
+        shell: bash
+        run: node scripts/validate-webgl-build.mjs "$GAME_DIR"
+
+      - name: Confirm only this game changed
+        shell: bash
+        run: |
+          set -euo pipefail
+          # The pull request must contain the selected game and nothing else, so the diff stays
+          # reviewable and a promotion cannot smuggle in an unrelated change.
+          unexpected="$(git status --porcelain -- . ":(exclude)public/game/${GAME_DIR}")"
+          if [ -n "$unexpected" ]; then
+            echo "Promotion changed files outside public/game/${GAME_DIR}:"
+            echo "$unexpected"
+            exit 1
+          fi
+
+      - name: Open pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: release/${{ inputs.game }}-${{ needs.build.outputs.source_short_sha }}
+          base: develop
+          commit-message: "build: promote ${{ inputs.game }} WebGL ${{ needs.build.outputs.source_short_sha }}"
+          title: "Promote ${{ inputs.game }} WebGL build ${{ needs.build.outputs.source_short_sha }}"
+          delete-branch: true
+          add-paths: public/game/${{ inputs.game == 'penguin-run' && 'PenguinRun' || 'StatesOfMatter' }}
+          body: |
+            Automated Unity WebGL promotion.
+
+            | Field | Value |
+            | --- | --- |
+            | Game | `${{ inputs.game }}` |
+            | Source repository | `${{ env.SOURCE_REPOSITORY }}` |
+            | Source revision | `${{ needs.build.outputs.source_sha }}` |
+            | Unity version | `${{ needs.build.outputs.unity_version }}` |
+            | Build run | ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} |
+
+            The artifact was validated for a loader, framework, wasm, and data asset of plausible
+            size, an `index.html` referencing the loader, and complete provenance markers. The diff
+            was checked to contain only `public/game/${{ inputs.game == 'penguin-run' && 'PenguinRun' || 'StatesOfMatter' }}`.
+
+            Merging deploys to production through Vercel. To roll back, revert the merge commit and
+            confirm with `curl -s https://<site>/api/health | jq '.checks.games'`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,11 @@ jobs:
           # Add additional environment variables here
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ vars.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
           CLERK_SECRET_KEY: ${{ secrets.CLERK_SECRET_KEY }}
+      # Catches a truncated or incompletely promoted game build before it can merge, rather than
+      # letting it reach a child as a blank canvas.
+      - name: Validate embedded WebGL builds
+        run: node scripts/validate-webgl-build.mjs
+
       - name: Run tests
         run: npm test
         env:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -110,6 +110,26 @@ curl -s https://<site>/api/health | jq '.checks.games'
 
 Then revert the commit that promoted it, and re-check that `sourceSha` moved back.
 
+## Releasing a game build
+
+Promotion is driven by the **build-unity-webgl** workflow. Do not copy artifacts by hand.
+
+1. Actions → **build-unity-webgl** → Run workflow.
+2. Choose the game and the exact source commit, tag, or branch to build.
+3. Leave **promote** enabled to open a website pull request automatically.
+
+The workflow builds the requested revision, stamps provenance markers, validates that the artifact
+has a loader, framework, wasm, and data asset of plausible size plus an `index.html` that references
+the loader, and confirms the diff touches only that game's directory. It then opens a pull request
+stating the source repository, full source SHA, Unity version, and a link to the build run.
+
+The promotion job can push a branch and open a pull request and nothing else. It cannot merge or
+deploy: a human reviews and merges, and merging is what deploys.
+
+If the build fails validation, no pull request is opened and the deployed site is untouched.
+
+Concurrency is keyed per game, so two promotions of the same game cannot interleave.
+
 ## Database backup and restore
 
 MongoDB Atlas takes the backups; this repository holds no copy of learner data.

--- a/scripts/validate-webgl-build.mjs
+++ b/scripts/validate-webgl-build.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+/**
+ * Validates an embedded Unity WebGL build.
+ *
+ * A build that is missing or truncated does not fail loudly — it renders as a blank canvas for a
+ * child, which is the worst possible way to find out. This checks the things that must be true for
+ * the build to boot at all, so an incomplete promotion fails in CI instead of in a classroom.
+ *
+ * Usage: node scripts/validate-webgl-build.mjs [gameDir ...]
+ *        node scripts/validate-webgl-build.mjs --root <dir> StatesOfMatter PenguinRun
+ */
+import { readFile, readdir, stat } from "node:fs/promises";
+import path from "node:path";
+
+const MARKERS = ["_build_id.txt", "_source_sha.txt", "_source_repository.txt", "_built_at_utc.txt"];
+
+// Unity emits these with varying compression suffixes depending on build settings, so match by role.
+const REQUIRED_ASSET_PATTERNS = [
+  { role: "loader", pattern: /\.loader\.js$/ },
+  { role: "framework", pattern: /\.framework\.js(\.(br|gz))?$/ },
+  { role: "wasm", pattern: /\.wasm(\.(br|gz))?$/ },
+  { role: "data", pattern: /\.data(\.(br|gz))?$/ },
+];
+
+const MIN_ASSET_BYTES = 1024;
+
+async function exists(target) {
+  try {
+    await stat(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function validateGame(root, game) {
+  const problems = [];
+  const gameDir = path.join(root, game);
+
+  if (!(await exists(gameDir))) {
+    return [`${game}: directory not found at ${gameDir}`];
+  }
+
+  const indexPath = path.join(gameDir, "index.html");
+  if (!(await exists(indexPath))) {
+    problems.push(`${game}: index.html is missing`);
+  }
+
+  for (const marker of MARKERS) {
+    const markerPath = path.join(gameDir, marker);
+    if (!(await exists(markerPath))) {
+      problems.push(`${game}: provenance marker ${marker} is missing`);
+      continue;
+    }
+    const contents = (await readFile(markerPath, "utf8")).trim();
+    if (!contents) problems.push(`${game}: provenance marker ${marker} is empty`);
+  }
+
+  const buildDir = path.join(gameDir, "Build");
+  if (!(await exists(buildDir))) {
+    problems.push(`${game}: Build/ directory is missing`);
+    return problems;
+  }
+
+  const entries = await readdir(buildDir);
+  for (const { role, pattern } of REQUIRED_ASSET_PATTERNS) {
+    const match = entries.find((entry) => pattern.test(entry));
+    if (!match) {
+      problems.push(`${game}: no ${role} asset found in Build/`);
+      continue;
+    }
+
+    // A zero-byte or near-empty asset is the signature of a truncated copy, which is otherwise
+    // indistinguishable from a healthy build by file listing alone.
+    const { size } = await stat(path.join(buildDir, match));
+    if (size < MIN_ASSET_BYTES) {
+      problems.push(`${game}: ${role} asset ${match} is only ${size} bytes, which cannot be a real build`);
+    }
+  }
+
+  if (await exists(indexPath)) {
+    const html = await readFile(indexPath, "utf8");
+    if (!/\.loader\.js/.test(html)) {
+      problems.push(`${game}: index.html does not reference a loader script`);
+    }
+  }
+
+  return problems;
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  let root = path.join(process.cwd(), "public", "game");
+
+  const rootFlag = argv.indexOf("--root");
+  if (rootFlag !== -1) {
+    root = path.resolve(argv[rootFlag + 1]);
+    argv.splice(rootFlag, 2);
+  }
+
+  const games = argv.length ? argv : ["StatesOfMatter", "PenguinRun"];
+  const problems = (await Promise.all(games.map((game) => validateGame(root, game)))).flat();
+
+  if (problems.length) {
+    console.error("WebGL build validation failed:");
+    for (const problem of problems) console.error(`  - ${problem}`);
+    process.exit(1);
+  }
+
+  console.log(`WebGL build validation passed for: ${games.join(", ")}`);
+}
+
+await main();


### PR DESCRIPTION
Advances #48.

## Why

The build workflow already produced an artifact, but getting it into the site meant downloading it, copying files by hand, updating markers, and hoping nothing was missed. A truncated copy does not fail loudly — it renders as a **blank canvas for a child**, which is the worst possible way to discover it.

## Promotion job

Downloads the artifact, replaces the game directory, validates the result, confirms the diff touches only that game, and opens a pull request stating source repository, full source SHA, Unity version, and a link to the build run.

Its token can push a branch and open a pull request and **nothing else** — it cannot merge or deploy. A human still approves, and a failed build cannot alter the deployed site.

## `scripts/validate-webgl-build.mjs`

Checks what must hold for a build to boot: a loader, framework, wasm, and data asset each of plausible size, an `index.html` that references the loader, and complete provenance markers.

The size floor matters — a near-empty asset is the signature of a truncated copy and is otherwise indistinguishable from a healthy build by file listing alone.

CI runs it on every pull request, so a bad build cannot merge, not just cannot be promoted. Verified passing against both currently committed builds.

## Rollback

Documented in `docs/operations.md`: identify the live build with `curl -s https://<site>/api/health | jq '.checks.games'`, revert the promoting commit, confirm `sourceSha` moved back. The health endpoint added in #65 is what makes a rollback verifiable rather than assumed.

## What is left open on #48

I could not execute the workflow — it needs Unity license secrets and a ~90 minute build. The promotion path is written and its validator is tested against real builds, but the first real run should be done with `promote` disabled to confirm the build half still works, then re-run with it enabled.

## Verification

- `node scripts/validate-webgl-build.mjs` — passes on both committed builds
- `npm test -- --run` — 128 passed
- `npm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)