### PR TITLE
Add a release gate and document the production branch split

### DIFF
--- a/.github/workflows/promote-to-production.yml
+++ b/.github/workflows/promote-to-production.yml
@@ -1,0 +1,85 @@
+name: promote-to-production
+
+run-name: Promote ${{ inputs.source_ref }} to production
+
+# Turns a deploy into a deliberate act. `develop` currently deploys straight to production on every
+# merge, which means no one ever decides to release — it just happens. This workflow fast-forwards
+# `main` to a chosen, already-verified commit so `main` records exactly what is live.
+on:
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: Commit or branch to promote (must already be on develop)
+        required: true
+        default: develop
+        type: string
+
+permissions:
+  contents: write
+
+# Two promotions at once would race on the same ref.
+concurrency:
+  group: promote-to-production
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: Fast-forward main
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve and verify the candidate
+        id: candidate
+        shell: bash
+        run: |
+          set -euo pipefail
+          sha="$(git rev-parse "origin/${{ inputs.source_ref }}" 2>/dev/null || git rev-parse "${{ inputs.source_ref }}")"
+
+          # Only promote something that is actually on develop. Promoting an arbitrary ref would put
+          # code into production that never went through review or CI.
+          if ! git merge-base --is-ancestor "$sha" origin/develop; then
+            echo "::error::${{ inputs.source_ref }} ($sha) is not an ancestor of develop."
+            exit 1
+          fi
+
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "Promoting $sha" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Require a green CI run for that commit
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          sha="${{ steps.candidate.outputs.sha }}"
+          conclusion="$(gh run list --repo "$GITHUB_REPOSITORY" --commit "$sha" --workflow ci --limit 1 --json conclusion --jq '.[0].conclusion // "none"')"
+
+          if [ "$conclusion" != "success" ]; then
+            echo "::error::CI for $sha is '$conclusion', not success. Refusing to promote."
+            exit 1
+          fi
+
+      - name: Fast-forward main
+        shell: bash
+        run: |
+          set -euo pipefail
+          sha="${{ steps.candidate.outputs.sha }}"
+
+          git fetch origin main:main 2>/dev/null || git branch main "$sha"
+          # Fast-forward only: main must never diverge from develop's history, so a promotion is
+          # always a subset of what has been reviewed.
+          git checkout main
+          git merge --ff-only "$sha"
+          git push origin main
+
+          {
+            echo "### Promoted to production"
+            echo "- Commit: \`$sha\`"
+            echo "- Verify: \`curl -s https://<site>/api/health | jq .release\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -166,8 +166,9 @@ including a class currently in session.
 
 ## Known operational characteristics
 
-- **`develop` is production.** There is no staging branch or release gate; a merge deploys. Treat
-  every merge to `develop` as a production change.
+- **`develop` is production today.** There is no staging branch or release gate; a merge deploys.
+  Treat every merge to `develop` as a production change. [releases.md](./releases.md) describes the
+  `main`/`develop` split that replaces this, and the single Vercel setting that switches it on.
 - **Classroom sessions expire after 8 hours.** An educator reporting that "the code stopped working"
   is usually an expired session, not an outage. They can reopen the class from Class History, which
   issues a new code.

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -1,0 +1,87 @@
+# Releases and Branch Topology
+
+## Where things stand today
+
+**`develop` is production.** It is the repository default branch, and Vercel deploys production from
+it. Every merged pull request goes live immediately. There is no staging environment and no moment
+at which someone decides to release — it simply happens.
+
+That is workable for a team shipping to itself. It is a poor fit for a product used by children in
+classrooms, where a bad deploy lands in the middle of a live lesson.
+
+## The target
+
+| Branch    | Role                                                                   |
+| --------- | ---------------------------------------------------------------------- |
+| `main`    | What is live. Only ever fast-forwarded to a verified `develop` commit. |
+| `develop` | Integration. Pull requests merge here and get a preview deploy.        |
+
+`main` never diverges from `develop`'s history, so anything in production is always a subset of what
+has been reviewed and passed CI.
+
+## Enabling it
+
+Three steps. The first two are in this repository; **the third is the one that actually switches
+production over and can only be done from the Vercel dashboard.**
+
+1. **Create `main` from a known-good `develop` commit.**
+
+   ```sh
+   git fetch origin
+   git branch main origin/develop
+   git push origin main
+   ```
+
+2. **Protect both branches** — Settings → Branches:
+
+   - `main`: no direct pushes; allow the promotion workflow only.
+   - `develop`: require a pull request and a passing `ci` check before merge.
+
+3. **Point Vercel at `main`** — Project → Settings → Git → **Production Branch** → `main`.
+
+   Until this is done, `main` exists but nothing reads it, and `develop` continues to deploy to
+   production. This is the single switch that changes behaviour, and it is deliberately left to a
+   person with dashboard access rather than assumed.
+
+Optionally set the repository default branch to `main` so clones and pull requests point at the
+right place. Existing pull requests targeting `develop` are unaffected.
+
+## Releasing
+
+Once enabled, run **Actions → promote-to-production** and give it a commit or branch (default
+`develop`).
+
+The workflow refuses to promote unless:
+
+- the commit is an **ancestor of `develop`** — promoting an arbitrary ref would put code into
+  production that never went through review; and
+- the **`ci` run for that exact commit concluded `success`** — a green run on a different commit
+  proves nothing about this one.
+
+It then fast-forwards `main`, which is what Vercel deploys. Confirm with:
+
+```sh
+curl -s https://<site>/api/health | jq .release
+```
+
+## Rolling back
+
+Both paths are in [operations.md](./operations.md). In summary:
+
+- **Fastest:** Vercel → Deployments → last known-good → Promote to Production. No git operation, and
+  it takes effect immediately. Use this during a live class.
+- **Durable:** revert the offending commit on `develop`, then promote again. Use this when the bad
+  change must not return on the next release.
+
+Reverting on `develop` without promoting does **not** change production once `main` is the
+production branch — that is the point of the split, and the thing most likely to surprise someone
+used to the current setup.
+
+## Before the switch
+
+- [ ] `main` created and pushed
+- [ ] Branch protection configured on `main` and `develop`
+- [ ] Vercel production branch changed to `main`
+- [ ] One promotion run end to end, and `/api/health` confirms the release SHA
+- [ ] One rollback rehearsed via Vercel instant rollback
+- [ ] `docs/operations.md` updated to say `main` is production rather than `develop`


### PR DESCRIPTION
## Problem

`develop` **is** production. It is the default branch and Vercel deploys production from it, so every merged pull request goes live immediately. There is no staging and no moment at which anyone decides to release — it just happens.

That is fine for a team shipping to itself. It is a poor fit for a product used by children in classrooms, where a bad deploy lands in the middle of a live lesson.

## `promote-to-production` workflow

Fast-forwards `main` to a chosen commit, so `main` records exactly what is live. It refuses to promote unless:

- the commit is an **ancestor of `develop`** — promoting an arbitrary ref would put code into production that never went through review;
- the **`ci` run for that exact commit concluded `success`** — a green run on a different commit proves nothing about this one.

Fast-forward only, so `main` can never diverge from reviewed history.

## `docs/releases.md`

Carries the migration. Two steps are in this repository — create `main`, configure branch protection. **The third is not:** pointing Vercel's Production Branch at `main` is what actually switches production over, and it can only be done from the dashboard.

I have deliberately not created `main` in this PR. Creating it while Vercel still deploys `develop` produces a branch that looks authoritative and immediately goes stale, which is worse than not having it. The doc has the one-line command, and it should be run at the moment the Vercel setting changes.

The doc also calls out the consequence most likely to catch someone out: **once `main` is production, reverting on `develop` no longer changes what is live.**

## Scope

This is the plumbing and the decision record. Someone with Vercel and repository-settings access has to throw the switch — that is one dashboard change and one `git push`, both written out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)