### PR TITLE
Ask the quiz questions about the science, not the game

### DIFF
--- a/src/data/quiz.json
+++ b/src/data/quiz.json
@@ -4,20 +4,38 @@
       "questionId": "som_q1",
       "question": "What does heating water turn it into?",
       "options": [
-        { "id": "A", "text": "Ice" },
-        { "id": "B", "text": "Plasma" },
-        { "id": "C", "text": "Steam" }
+        {
+          "id": "A",
+          "text": "Ice"
+        },
+        {
+          "id": "B",
+          "text": "Plasma"
+        },
+        {
+          "id": "C",
+          "text": "Steam"
+        }
       ],
       "correctOptionId": "C",
       "correctAnswer": "Steam"
     },
     {
       "questionId": "som_q2",
-      "question": "When you cool down juice it turns into?",
+      "question": "When you cool down juice, what does it turn into?",
       "options": [
-        { "id": "A", "text": "Popsicle" },
-        { "id": "B", "text": "Chocolate" },
-        { "id": "C", "text": "Cookie" }
+        {
+          "id": "A",
+          "text": "Popsicle"
+        },
+        {
+          "id": "B",
+          "text": "Chocolate"
+        },
+        {
+          "id": "C",
+          "text": "Cookie"
+        }
       ],
       "correctOptionId": "A",
       "correctAnswer": "Popsicle"
@@ -26,9 +44,18 @@
       "questionId": "som_q3",
       "question": "What does gas turn into when heated?",
       "options": [
-        { "id": "A", "text": "Plasma" },
-        { "id": "B", "text": "Solid" },
-        { "id": "C", "text": "Liquid" }
+        {
+          "id": "A",
+          "text": "Plasma"
+        },
+        {
+          "id": "B",
+          "text": "Solid"
+        },
+        {
+          "id": "C",
+          "text": "Liquid"
+        }
       ],
       "correctOptionId": "A",
       "correctAnswer": "Plasma"
@@ -37,32 +64,56 @@
   "penguinRunQuiz": [
     {
       "questionId": "pr_q1",
-      "question": "What force pulls the penguin down the track?",
+      "question": "What force pulls things down?",
       "options": [
-        { "id": "A", "text": "Magnetism" },
-        { "id": "B", "text": "Gravity" },
-        { "id": "C", "text": "Electricity" }
+        {
+          "id": "A",
+          "text": "Magnetism"
+        },
+        {
+          "id": "B",
+          "text": "Gravity"
+        },
+        {
+          "id": "C",
+          "text": "Electricity"
+        }
       ],
       "correctOptionId": "B",
       "correctAnswer": "Gravity"
     },
     {
       "questionId": "pr_q2",
-      "question": "When the penguin is at the top of the coaster, it has the most Potential Energy:",
+      "question": "When something is at the very top, it has the most Potential Energy:",
       "options": [
-        { "id": "A", "text": "True" },
-        { "id": "B", "text": "False" }
+        {
+          "id": "A",
+          "text": "True"
+        },
+        {
+          "id": "B",
+          "text": "False"
+        }
       ],
       "correctOptionId": "A",
       "correctAnswer": "True"
     },
     {
       "questionId": "pr_q3",
-      "question": "What can slow the penguin down on the track?",
+      "question": "What can slow things down when they slide?",
       "options": [
-        { "id": "A", "text": "Friction" },
-        { "id": "B", "text": "Gravity" },
-        { "id": "C", "text": "Speed" }
+        {
+          "id": "A",
+          "text": "Friction"
+        },
+        {
+          "id": "B",
+          "text": "Gravity"
+        },
+        {
+          "id": "C",
+          "text": "Speed"
+        }
       ],
       "correctOptionId": "A",
       "correctAnswer": "Friction"


### PR DESCRIPTION
## Problem

The Penguin Run questions asked about "the penguin", "the track", and "the coaster".

`getQuizQuestions(quizId)` takes **no phase parameter** — the same questions serve the pre-quiz and the post-quiz. So the pre-quiz, which runs *before a child has seen the game at all*, was asking about a penguin they had never met. Those questions were unanswerable by design for the learner they were measuring.

That matters beyond wording: the **pre-to-post gain is the number the organisation reports**, and it is only meaningful if both halves measure understanding rather than familiarity with a screen the child had not yet seen.

## Changes

| Before | After |
| --- | --- |
| What force pulls **the penguin** down **the track**? | What force pulls **things** down? |
| When **the penguin** is at the top of **the coaster**, it has the most Potential Energy: | When **something** is at the very top, it has the most Potential Energy: |
| What can slow **the penguin** down **on the track**? | What can slow **things** down when they slide? |

"Potential Energy" is kept — naming the concept is the point of that question. Only the penguin and the coaster are removed.

The **States of Matter questions already asked about the world rather than the game** ("What does heating water turn it into?"), so only one grammar fix was needed there: *"When you cool down juice it turns into?"* → *"When you cool down juice, what does it turn into?"*

## Scoring is unaffected

Verified rather than assumed:

- **Answer options, correct answers, question ids, and the count per quiz are all unchanged.** The count matters — scoring normalises the score by it.
- Scoring matches on `correctAnswer`, never on question text.
- `questionText` is only *stored* in results as a record of what was asked. Existing results keep the wording they were answered under, which is correct.

## Also

Deletes the empty `quiz.json` at the repository root. It has been **zero bytes since May** and nothing imports it — every consumer reads `src/data/quiz.json`. It only existed to be mistaken for the real file.

## Verification

- `npm test -- --run` — 128 passed
- `npm run lint` — 0 errors
- `npx tsc --noEmit` — clean across `src/`
- `next build` — compiles
- Integrity check confirming every `correctAnswer` still matches its `correctOptionId` option text

🤖 Generated with [Claude Code](https://claude.com/claude-code)