### PR TITLE
Let the promotion pull request run its own checks

### DIFF
--- a/.github/workflows/build-unity-webgl.yml
+++ b/.github/workflows/build-unity-webgl.yml
@@ -229,6 +229,15 @@ jobs:
       - name: Open pull request
         uses: peter-evans/create-pull-request@v6
         with:
+          # A pull request opened with the default GITHUB_TOKEN does not start `on: pull_request`
+          # workflows — GitHub suppresses them to avoid a workflow triggering itself. That left the
+          # promotion pull request without the site build, and so without the WebGL validation that
+          # runs inside it, which is the one case that check exists for. A personal access token
+          # makes the pull request look like a human's, so checks run normally.
+          #
+          # Falls back to the default token when the secret is unset: promotion still works, but its
+          # checks then need approving by hand from the Actions tab.
+          token: ${{ secrets.UNITY_REPO_TOKEN || github.token }}
           branch: release/${{ inputs.game }}-${{ needs.build.outputs.source_short_sha }}
           base: develop
           commit-message: "build: promote ${{ inputs.game }} WebGL ${{ needs.build.outputs.source_short_sha }}"

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -128,6 +128,12 @@ deploy: a human reviews and merges, and merging is what deploys.
 
 If the build fails validation, no pull request is opened and the deployed site is untouched.
 
+**Check the promotion pull request has run its checks.** A pull request opened by a workflow using
+the default token does not start `on: pull_request` workflows, so the site build — and the WebGL
+validation inside it — can be missing. The workflow uses a personal access token to avoid this. If
+the checks are absent or show "action required", approve the run from the **Actions** tab before
+merging; merging without them skips the validation that catches an incomplete artifact.
+
 Concurrency is keyed per game, so two promotions of the same game cannot interleave.
 
 ## Database backup and restore


### PR DESCRIPTION
Found by running the promotion automation for real for the first time (#72).

## The hole

A pull request opened with the default `GITHUB_TOKEN` **does not start `on: pull_request` workflows** — GitHub suppresses them so a workflow cannot trigger itself.

So #72 arrived with only Vercel and GitGuardian. No site build, no tests.

That matters more than it first looks: `scripts/validate-webgl-build.mjs` runs *inside* the `ci` workflow. The check built to stop a truncated game build from merging was the exact check that did not run on **the only kind of pull request that carries a game build**. The claim in #67 that a bad build cannot merge was not true for promotions.

It also fails quietly. A promotion PR with no checks looks healthy at a glance — the Vercel and GitGuardian ticks are there and green.

## Fix

Use the existing `UNITY_REPO_TOKEN` secret for `create-pull-request`, so the PR looks like a person's and checks run normally.

It falls back to the default token when that secret is unset (`secrets.UNITY_REPO_TOKEN || github.token`): promotion still works, and its checks then need approving by hand from the Actions tab.

**I could not verify the token end to end** — I cannot read a secret's value or scopes, and the only real test is the next promotion run. If `UNITY_REPO_TOKEN` turns out to lack `repo` scope or to have expired, the step will fail rather than silently fall back, since `||` only catches an empty value. Worth watching on the next release.

## Documented

The runbook now says to check that a promotion PR actually ran its checks, and how to approve the run if not. That is deliberate: the automated fix should work, but the failure mode is invisible enough to deserve a written check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)