### PR TITLE
Wait for the bridge, and stop the States suite drifting from it

### DIFF
--- a/e2e/states-completion.spec.ts
+++ b/e2e/states-completion.spec.ts
@@ -1,4 +1,9 @@
-import { expect, test, type Page, type Route } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
+
+// This suite kept its own copy of the bridge harness while the Penguin suite moved to the shared
+// one, and the two drifted: the copy here never stubbed /api/gameData/mine, so these tests quietly
+// depended on a real database and could not run locally at all.
+import { jsonResponse, prepareGamePage, sendUnityProgress } from "./support/gameBridge";
 
 const completedStageIds = [
   "matter-kitchen/freeze-juice",
@@ -9,58 +14,12 @@ const completedStageIds = [
   "state-lab/melt-wax",
 ];
 
-const unityShell = `<!doctype html>
-<html>
-  <body>
-    <script>
-      window.parent.postMessage({ type: "unity-ready" }, window.location.origin);
-    </script>
-  </body>
-</html>`;
-
-async function prepareGamePage(page: Page) {
-  await page.route("**/game/StatesOfMatter/index.html", (route) =>
-    route.fulfill({ status: 200, contentType: "text/html", body: unityShell }),
-  );
-  await page.route("**/threeStatesOfMatterQuiz**", (route) =>
-    route.fulfill({ status: 200, contentType: "text/html", body: "<!doctype html><title>Post-game quiz</title>" }),
-  );
-  await page.route("**/api/users/me", (route) => route.fulfill({ status: 401, body: "{}" }));
-}
-
-async function sendUnityProgress(page: Page, payload: Record<string, unknown>) {
-  await expect
-    .poll(() => page.frames().some((frame) => frame.url().includes("/game/StatesOfMatter/index.html")), {
-      message: "States of Matter iframe should be loaded",
-    })
-    .toBe(true);
-  const unityFrame = page.frames().find((frame) => frame.url().includes("/game/StatesOfMatter/index.html"));
-
-  await unityFrame!.evaluate((progressPayload) => {
-    window.parent.postMessage(
-      {
-        type: "unity-progress",
-        payload: progressPayload,
-      },
-      window.location.origin,
-    );
-  }, payload);
-}
-
 function sendCompletion(page: Page) {
-  return sendUnityProgress(page, { completedStageIds, gameCompleted: true });
-}
-
-function jsonResponse(route: Route, body: unknown) {
-  return route.fulfill({
-    status: 200,
-    contentType: "application/json",
-    body: JSON.stringify(body),
-  });
+  return sendUnityProgress(page, "StatesOfMatter", { completedStageIds, gameCompleted: true });
 }
 
 test.beforeEach(async ({ page }) => {
-  await prepareGamePage(page);
+  await prepareGamePage(page, "StatesOfMatter", "/threeStatesOfMatterQuiz");
 });
 
 test("saves final States progress before routing once to the post-game quiz", async ({ page }) => {
@@ -441,7 +400,7 @@ test("requires rejoin instead of falling back to a personal save after classroom
 
   await page.goto("/statesOfMatterGame");
   await expect(page.locator('iframe[title="StatesOfMatter"]')).toBeVisible();
-  await sendUnityProgress(page, { completedStageIds: [completedStageIds[0]] });
+  await sendUnityProgress(page, "StatesOfMatter", { completedStageIds: [completedStageIds[0]] });
   await expect.poll(() => page.evaluate((key) => window.localStorage.getItem(key), classroomSessionKey)).toBeNull();
 
   await sendCompletion(page);

--- a/e2e/support/gameBridge.ts
+++ b/e2e/support/gameBridge.ts
@@ -38,6 +38,12 @@ export async function prepareGamePage(page: Page, game: GameKey, quizPath: strin
 export async function sendUnityProgress(page: Page, game: GameKey, payload: Record<string, unknown>) {
   const framePath = `/game/${game}/index.html`;
 
+  // Wait for the bridge, not the iframe. The iframe resolves first -- markedly so after a reload,
+  // where it comes from cache while the page still has to hydrate -- and postMessage drops a message
+  // that arrives before the listener exists, silently and with no error. Waiting on the iframe alone
+  // made this helper lose completions on slower runners.
+  await expect(page.locator(`iframe[title="${game}"][data-bridge-ready="true"]`)).toBeAttached();
+
   await expect
     .poll(() => page.frames().some((frame) => frame.url().includes(framePath)), {
       message: `${game} iframe should be loaded`,

--- a/src/components/UnityIFrame.tsx
+++ b/src/components/UnityIFrame.tsx
@@ -86,7 +86,18 @@ export default function UnityIFrame({
       }
     }
     window.addEventListener("message", handleMessage);
-    return () => window.removeEventListener("message", handleMessage);
+
+    // Marks the bridge as live. postMessage drops a message with no listener
+    // silently and with no error, so anything driving the game from outside
+    // has to wait for this rather than for the iframe -- the iframe loads
+    // first, and a progress message sent in that gap is lost for good.
+    const iframe = iframeRef.current;
+    iframe?.setAttribute("data-bridge-ready", "true");
+
+    return () => {
+      iframe?.removeAttribute("data-bridge-ready");
+      window.removeEventListener("message", handleMessage);
+    };
   }, [saveId, userId, sessionId, classroomId, onProgress]);
 
   // UPDATE: url no longer needs saveId since its sent in site-context


### PR DESCRIPTION
CI is red on `develop`. Since `develop` **is** production, that matters — though to be clear about blast radius, the Vercel deploy is independent of this workflow, so the promoted game builds did reach the site.

## Not a regression

Run [33335291895](https://github.com/hack4impact-calpoly/kids-first-initiative-site/actions/runs/33335291895) at `72f24f41`: `build (20.x)` **failed**, `build (22.x)` **passed** — same commit, same tests. That rules out the code and points at timing.

## Fault 1 — the harness raced the listener

`sendUnityProgress` waited for the **iframe** and then fired a single `postMessage`. `postMessage` drops a message that arrives before a listener exists — silently, no error, no retry — and `UnityIFrame` attaches its listener in a `useEffect`.

After `page.reload()` the iframe returns from cache almost immediately while the parent still has to hydrate. On a slow enough runner the completion lands in that gap and is lost. The test then sits on `/statesOfMatterGame` forever, which is exactly what CI reported.

`UnityIFrame` now sets `data-bridge-ready` when the listener is live, and the harness waits for **that** rather than for the iframe.

## Fault 2 — the failing test never used that harness

`states-completion.spec.ts` kept an **inline copy** of the harness from before the shared one was extracted in #64, and the two drifted. The copy never stubbed `/api/gameData/mine`, so these tests quietly depended on a real database.

That is why the flake was invisible outside CI: locally **11 of 13 failed** with `Frame was detached`. Nobody could have reproduced this on a laptop. The suite now uses `e2e/support/gameBridge.ts`, so there is one bridge contract instead of two copies drifting apart.

## Verification

| Check | Before | After |
| --- | --- | --- |
| `states-completion` locally | 2/13 | 13/13 |
| Full e2e suite, ×3 repeats | could not run | **54/54** |
| `tsc --noEmit` | 1 error (caught a missed call site) | clean |
| `npm test` | 128 passed | 128 passed |
| `npm run lint` | 0 errors, 6 warnings | unchanged |

The typechecker caught a call site I missed during the migration — worth noting, since the inline helper's looser signature was part of how the drift went unnoticed.

## Honest limit

I fixed a **mechanism** that would drop a completion, and the reload race is a real instance of it. I can't prove that specific CI run failed for that reason and not another — the failure isn't reproducible on demand. What I can say: the suite now runs locally, so the next person to hit this can actually debug it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)