### PR TITLE
Let the promotion build accept any commit, not just branches and tags

### DIFF
--- a/.github/workflows/build-unity-webgl.yml
+++ b/.github/workflows/build-unity-webgl.yml
@@ -51,10 +51,36 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ env.SOURCE_REPOSITORY }}
-          ref: ${{ inputs.source_ref }}
           path: unity-source
           fetch-depth: 0
           lfs: true
+
+      # actions/checkout resolves its ref as a branch or tag only. A short commit SHA -- the most
+      # natural thing to paste after merging something -- is neither, so it failed the run in
+      # seconds with "a branch or tag with the name ... could not be found", before Unity started.
+      # The input has always been described as accepting a commit. The full history is already
+      # here, so resolve it with git, which accepts every form.
+      - name: Check out the requested source ref
+        shell: bash
+        working-directory: unity-source
+        run: |
+          set -euo pipefail
+          ref='${{ inputs.source_ref }}'
+
+          sha="$(git rev-parse --verify --quiet "origin/${ref}^{commit}" || true)"
+          if [ -z "$sha" ]; then
+            sha="$(git rev-parse --verify --quiet "${ref}^{commit}" || true)"
+          fi
+          if [ -z "$sha" ]; then
+            echo "::error::'${ref}' is not a branch, tag, or commit in ${SOURCE_REPOSITORY}"
+            exit 1
+          fi
+
+          git checkout --quiet --detach "$sha"
+          # The clone landed on the default branch, so LFS pointers for this commit may not be
+          # fetched yet. A build from unresolved pointers looks fine until the game is blank.
+          git lfs pull
+          echo "Building ${ref} -> $(git rev-parse HEAD)"
 
       - name: Record source revision
         id: source


### PR DESCRIPTION
Hit this while promoting the Penguin Run guides fix.

## What happened

`source_ref` is described in the workflow as *"Source branch, tag, or commit"*, but it was passed straight to `actions/checkout`, which resolves **branches and tags only**. Passing a short SHA — the natural thing to paste after merging something — failed in seconds:

```
##[error]A branch or tag with the name '690d3f9' could not be found
```

The run died before Unity started. The input's own description was wrong about what it accepted.

## Fix

The clone already uses `fetch-depth: 0`, so the full history is present. `git rev-parse` resolves the ref instead, accepting branches, tags, short SHAs and full SHAs alike, with a clear error when it genuinely doesn't exist.

It also runs `git lfs pull` afterwards. The clone now lands on the default branch before detaching, so LFS pointers for the requested commit may not be fetched — and **a build from unresolved pointers looks fine right up until the game renders blank**. That is the failure mode `validate-webgl-build.mjs` exists to catch, and it is not one worth relying on catching.

## Verification

The YAML parses. Beyond that this is only really testable by running a promotion, which is the next one — the same situation as `UNITY_REPO_TOKEN` in #73, so I want to flag it rather than imply it's proven. The failure mode it fixes is loud and immediate, not silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)