### PR TITLE
Rewrite the handbook in a conventional documentation voice

### DIFF
--- a/docs/handbook.md
+++ b/docs/handbook.md
@@ -1,143 +1,211 @@
-# KFI Project Handbook
+# Kids First Initiative — Project Handbook
 
-Plain-text companion to [index.html](./index.html). Same content, structured for search, grep, and AI
-assistants. Updated 29 August 2026.
+Kids First Initiative is a web platform that teaches STEM to children in underserved communities.
+Children play one of two Unity WebGL games and answer a short quiz before and after each one, so that
+what they learned can be measured.
 
-**Project:** Kids First Initiative — a web platform teaching STEM to children in underserved
-communities through two Unity WebGL games, bracketed by a pre-quiz and post-quiz so learning can be
-measured.
-**Repository:** `hack4impact-calpoly/kids-first-initiative-site`
-**Integration branch:** `develop` (which is also currently the production branch)
-**Stack:** Next.js 16.3.3, React 18, MongoDB via Mongoose 8, Clerk auth, Chakra UI 3, Vercel hosting
+This handbook is the plain-text companion to [index.html](./index.html), which presents the same
+material formatted for reading.
 
----
+- **Repository:** `hack4impact-calpoly/kids-first-initiative-site`
+- **Stack:** Next.js 16.3.3 (App Router), React 18, Mongoose 8, Clerk, Chakra UI 3
+- **Hosting:** Vercel
+- **Integration branch:** `develop`, which is currently also the production branch
+- **Last updated:** 31 August 2026
 
-## At a glance
+## Contents
 
-Counted from the repository. Each number carries its limitation, because a metric without one
-invites more confidence than it has earned.
-
-| Metric                | Value                    | Caveat                                                                                       |
-| --------------------- | ------------------------ | -------------------------------------------------------------------------------------------- |
-| Unit tests            | 128 across 15 files      | All mock MongoDB — connection ordering, index behaviour, and query shape are unverified here |
-| Browser tests         | 18 across 2 files        | The only layer exercising real wiring; cannot yet cover authorization                        |
-| Accessibility checks  | 26                       | Reports, does not gate — real violations remain; read the CI artifact                        |
-| API endpoints         | 33 across 22 route files | Identity always derived server-side                                                          |
-| Known vulnerabilities | 0                        | Down from 53, including a Clerk middleware auth bypass                                       |
-| Blocked on a person   | 6                        | Access or hardware, not code                                                                 |
-| Pages                 | 23                       | App Router                                                                                   |
-| Mongoose models       | 10                       |                                                                                              |
-| CI workflows          | 3                        | `ci`, `build-unity-webgl`, `promote-to-production`                                           |
+1. [Overview](#overview)
+2. [Getting started](#getting-started)
+3. [Architecture](#architecture)
+4. [Classroom sessions](#classroom-sessions)
+5. [API](#api)
+6. [Testing](#testing)
+7. [Releases](#releases)
+8. [Operations](#operations)
+9. [Outstanding work](#outstanding-work)
+10. [Further reading](#further-reading)
 
 ---
 
-## What the product does
+## Overview
 
-The product exists to **prove learning happened**, not just to entertain. That single goal explains
-most of its design: every game is bracketed by a quiz, and every result is attributable to a specific
-child in a specific class.
-
-**The learning loop:** pre-quiz → game → post-quiz. The difference between the two quizzes is the
-number the organisation cares about. Progress saves continuously during play, so a lost connection or
-closed tab does not cost a child their work.
+Each game is bracketed by a quiz. A child answers the pre-quiz, plays, then answers the post-quiz.
+The difference between the two scores is the outcome the organisation reports, so every result must
+be attributable to a particular child in a particular class. Progress saves continuously during play,
+which means a dropped connection or a closed tab does not lose a child's work.
 
 ### Games
 
-| Game             | Teaches                                 | Progress format                         | Location                      |
-| ---------------- | --------------------------------------- | --------------------------------------- | ----------------------------- |
-| States of Matter | Melting, freezing, condensing           | Completed **stage ids** (named puzzles) | `public/game/StatesOfMatter/` |
-| Penguin Run      | Gravity and friction via track building | Completed **level numbers**             | `public/game/PenguinRun/`     |
+| Game             | Teaches                                      | Reports progress as     | Build location                |
+| ---------------- | -------------------------------------------- | ----------------------- | ----------------------------- |
+| States of Matter | Melting, freezing, condensing                | Completed stage ids     | `public/game/StatesOfMatter/` |
+| Penguin Run      | Gravity and friction, through track building | Completed level numbers | `public/game/PenguinRun/`     |
 
-The two report progress differently, which is why each needs its own browser-test coverage rather
-than assuming equivalence.
+The two games report progress in different formats, so each has its own browser-test coverage.
 
 ### Roles
 
-| Role                | What they do                                                         | Identified by                                                        |
-| ------------------- | -------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| Learner (classroom) | Joins with a class code, plays, takes both quizzes                   | HTTP-only cookie tied to a participant record; **no account needed** |
-| Learner (personal)  | Signs in and plays independently                                     | Clerk account                                                        |
-| Educator            | Opens a class, shares a code, watches progress, reopens past classes | Clerk account with educator role, linked to a `Teacher` record       |
-| Administrator       | Cross-class analytics and learning outcomes                          | Clerk account with admin role                                        |
+| Role                | Capabilities                                                            | Identified by                                                      |
+| ------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Learner (classroom) | Joins with a class code, plays, answers both quizzes                    | HTTP-only cookie tied to a participant record                      |
+| Learner (personal)  | Signs in and plays independently                                        | Clerk account                                                      |
+| Educator            | Opens a class, shares the code, monitors progress, reopens past classes | Clerk account with the educator role, linked to a `Teacher` record |
+| Administrator       | Cross-class analytics and learning outcomes                             | Clerk account with the admin role                                  |
 
-**Why classroom learners have no accounts:** the audience is young children on shared school
-hardware. Requiring accounts would be a barrier and would collect far more personal data than the
-product needs.
-
----
-
-## Components
-
-| Component             | Responsibility                                                                                                                                       | Location                                                          |
-| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| Authorization layer   | API handlers are the security boundary — not page visibility, never a client-supplied id. Ownership derived server-side.                             | `src/lib/server/apiAuthorization.ts`, `classroomAuthorization.ts` |
-| Classroom history     | Pure functions grouping sessions into classes, merging rosters across reopens, computing metrics. No database calls, so it is testable in isolation. | `src/lib/server/classroomHistory.ts`                              |
-| Classroom data access | Loads class chains, class detail, and performs reopening                                                                                             | `src/lib/server/classroomClasses.ts`                              |
-| Unity bridge          | Games post progress over `postMessage`; the site saves it and routes to the post-quiz exactly once                                                   | `src/components/GamePlayer.tsx`, `UnityIFrame.tsx`                |
-| Quiz progress         | Reads the baseline recorded before playing. Read and write paths must agree on which record belongs to the learner.                                  | `src/lib/server/quizProgress.ts`                                  |
-| Admin analytics       | Aggregates outcomes across classes, states which sessions each number covers, counts classroom learners without accounts                             | `src/lib/server/adminAnalytics.ts`                                |
-| Observability         | Structured error reports with correlation id and release SHA; context accepts only primitives                                                        | `src/lib/server/observability.ts`                                 |
-| Quiz scoring          | Score normalisation shared by dashboards and history                                                                                                 | `src/lib/quizScoring.ts`                                          |
+Classroom learners do not have accounts. The audience is young children on shared school hardware,
+where account creation is both a barrier to starting a lesson and a larger collection of personal
+data than the platform needs.
 
 ---
 
-## The classroom data model
+## Getting started
 
-**The single most important concept.** Almost every bug in this area has come from misunderstanding
-it.
+### Prerequisites
 
-**A class is not a session — it is a chain of them.** When an educator reopens a closed class, the
-system does not revive the old session. It appends a new one linked back through `rootSessionId`.
-Historical records keep pointing at the sessions that produced them; nothing is rewritten or
+- Node.js 20 or 22. CI tests both.
+- A MongoDB connection string.
+- Clerk API keys. Ask a tech lead.
+
+### Setup
+
+```sh
+npm install
+npm run dev
+```
+
+Create a `.env` file in the repository root with three values, obtained from a tech lead:
+
+```
+MONGO_URI=
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
+CLERK_SECRET_KEY=
+```
+
+There is no `.env.example` in the repository; the list above is the current requirement.
+
+Install the Prettier and ESLint editor extensions and enable format on save. A Husky hook formats
+staged files on commit.
+
+### Commands
+
+| Command                                 | Purpose                                       |
+| --------------------------------------- | --------------------------------------------- |
+| `npm run dev`                           | Development server                            |
+| `npm test`                              | Unit tests                                    |
+| `npm run test:e2e`                      | Browser tests. Requires MongoDB               |
+| `npm run test:a11y`                     | Accessibility report                          |
+| `npm run lint`, `npm run lint:fix`      | ESLint                                        |
+| `npm run format`                        | Prettier                                      |
+| `npm audit`                             | Dependency vulnerabilities                    |
+| `node scripts/validate-webgl-build.mjs` | Verify both embedded game builds are complete |
+
+### Contributing
+
+Branch from `develop`. Run `npm run lint` and `npm test` before opening a pull request against
+`develop`. Do not branch from `main`; see [Releases](#releases) for why it may not exist yet.
+
+### Environment notes
+
+Several local failures have environmental causes:
+
+- **`next build` fails at prerender without Clerk keys.** Compilation and type checking have already
+  run by that point. To build locally with placeholder keys:
+
+  ```sh
+  PK="pk_test_$(printf 'example.clerk.accounts.dev$' | base64 | tr -d '\n')"
+  NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY="$PK" \
+    CLERK_SECRET_KEY="sk_test_0000000000000000000000000000000000000000" \
+    npm run build
+  ```
+
+- **`npx tsc --noEmit` reports pre-existing errors** in `e2e/` and `.next/`. Filter with
+  `grep -E '^src/'` to see whether your change is clean.
+- **Run `npm install` after switching branches.** Dependencies have moved substantially.
+- **The browser suite requires MongoDB**, which is not available in every environment. CI is the
+  authoritative check for both the build and the browser tests.
+
+---
+
+## Architecture
+
+| Area                  | Responsibility                                                                                                       | Location                                                          |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| Authorization         | API handlers are the security boundary. Ownership is derived server-side, never from a client-supplied id            | `src/lib/server/apiAuthorization.ts`, `classroomAuthorization.ts` |
+| Classroom history     | Groups sessions into classes, merges rosters across reopens, computes metrics. Pure functions with no database calls | `src/lib/server/classroomHistory.ts`                              |
+| Classroom data access | Loads class chains and class detail; performs reopening                                                              | `src/lib/server/classroomClasses.ts`                              |
+| Unity bridge          | Receives progress from the game over `postMessage`, saves it, and routes to the post-quiz once                       | `src/components/GamePlayer.tsx`, `UnityIFrame.tsx`                |
+| Quiz progress         | Reads the baseline score recorded before play                                                                        | `src/lib/server/quizProgress.ts`                                  |
+| Admin analytics       | Aggregates outcomes across classes and reports the scope each figure covers                                          | `src/lib/server/adminAnalytics.ts`                                |
+| Observability         | Structured error reports carrying a correlation id and release SHA                                                   | `src/lib/server/observability.ts`                                 |
+| Quiz scoring          | Score normalisation shared by the dashboards and class history                                                       | `src/lib/quizScoring.ts`                                          |
+
+The repository contains 23 pages under the App Router and 10 Mongoose schemas in `src/database/`.
+
+Hidden links and disabled buttons are user-interface conveniences and carry no security weight. All
+access decisions are enforced in the API handler.
+
+---
+
+## Classroom sessions
+
+Read this section before changing anything that touches a class. Most of the subtle bugs in this
+project have come from misreading the model below.
+
+A class is a chain of sessions, not a single record. When an educator reopens a closed class, the
+system appends a new session linked to the previous one; it does not reactivate the old session.
+Historical records continue to reference the sessions that produced them, so nothing is rewritten or
 re-attributed.
 
-| Concept                | Meaning                                                       | Consequence                                                                                                 |
-| ---------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| `rootSessionId`        | Head of the continuation chain; null on an original session   | A class is addressed by `rootSessionId ?? _id`                                                              |
-| `continuedFromId`      | The session this one continues                                | Chain ordering                                                                                              |
-| `participantKey`       | Stable per learner per class — `clerk:<id>` or `guest:<hash>` | A returning learner is one roster entry, not two. **Never send to a client** — it embeds a Clerk id         |
-| `status` + `expiresAt` | Session state is **derived, never stored**                    | `closed` means closed; `active` with a past expiry means expired. Always use `resolveClassroomSessionState` |
-| `participant:<id>`     | Owner key on a classroom learner's saves and quiz records     | Changes when they rejoin after a reopen; lineage resolution carries progress across                         |
+| Field                    | Meaning                                                      | Consequence                                                                                                      |
+| ------------------------ | ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| `rootSessionId`          | Head of the continuation chain; null on an original session  | A class is addressed by `rootSessionId ?? _id`                                                                   |
+| `continuedFromId`        | The session this one continues                               | Determines chain order                                                                                           |
+| `participantKey`         | Stable per learner per class: `clerk:<id>` or `guest:<hash>` | A returning learner collapses to a single roster entry. It embeds a Clerk id, so it must not be sent to a client |
+| `status` and `expiresAt` | Session state is derived, never stored                       | `closed` means closed; `active` with a past expiry means expired. Use `resolveClassroomSessionState`             |
+| `participant:<id>`       | Owner key on a classroom learner's saves and quiz records    | Changes when a learner rejoins after a reopen; lineage resolution carries their progress across                  |
 
-**Database-enforced invariant:** a unique partial index guarantees at most one active continuation
-per class, preventing two simultaneous reopens from leaving a class with two working access codes. It
-builds in the background; failure logs `ClassroomSession index build failed`. If a class shows two
-live sessions, check that index first.
+### Constraints and lifetime
 
-**Session lifetime:** classroom sessions expire after 8 hours. An educator reporting "the code
-stopped working" is usually an expiry, not an outage — they can reopen from Class History, which
-issues a new code and retires every previous one.
+A unique partial index permits at most one active continuation per class, which prevents two
+simultaneous reopens from leaving a class with two working access codes. The index builds in the
+background, and a failure logs `ClassroomSession index build failed`. If a class appears to have two
+live sessions, check the index first.
+
+Classroom sessions expire after 8 hours. An educator reporting that a code has stopped working has
+usually hit the expiry rather than an outage; they can reopen the class from Class History, which
+issues a new code and retires all previous ones.
 
 ---
 
-## API surface
+## API
 
-33 endpoints across 22 route files. Two conventions run throughout: **identity is derived on the
-server**, and an inaccessible resource answers `404` rather than `403` so it cannot be probed for.
+33 endpoints across 22 route files. Two conventions apply throughout: identity is derived on the
+server, and a resource the caller cannot access returns `404` rather than `403`, so its existence
+cannot be probed.
 
-| Route                                             | Methods        | Access                                                |
-| ------------------------------------------------- | -------------- | ----------------------------------------------------- |
-| `/api/health`                                     | GET            | Public — deployment health only, no learner data      |
-| `/api/classroom-sessions`                         | GET POST PATCH | Signed-in educator, scoped to own classes             |
-| `/api/classroom-sessions/join`                    | POST           | Public with active code; issues classroom credential  |
-| `/api/classroom-sessions/history`                 | GET            | Educator, own classes only                            |
-| `/api/classroom-sessions/history/:classId`        | GET            | Owning educator or administrator                      |
-| `/api/classroom-sessions/history/:classId/reopen` | POST           | Owning educator only — **no admin bypass**            |
-| `/api/gameData`                                   | GET POST       | GET admin; POST owner or credentialed participant     |
-| `/api/gameData/mine`                              | GET            | Caller's own saves, including classroom lineage       |
-| `/api/gameData/:saveId`                           | GET PATCH      | Owner, admin, or educator owning the classroom        |
-| `/api/quiz`, `/api/quiz/:id`                      | GET POST PUT   | Owner or admin; educators read within their classroom |
-| `/api/admin/analytics`                            | GET            | Administrator                                         |
-| `/api/admin/:id/role`                             | PATCH          | Administrator                                         |
-| `/api/auth/admin-access`                          | GET            | Administrator                                         |
-| `/api/users`, `/api/users/:id`                    | GET POST PUT   | Administrator                                         |
-| `/api/users/me`, `/api/users/me/photo`            | GET PATCH      | Signed-in user, own record                            |
-| `/api/sessions`, `/api/sessions/:sessionId`       | GET POST PATCH | Owner or administrator                                |
-| `/api/events`                                     | GET POST       | GET admin; POST owner or credentialed participant     |
+| Route                                             | Methods        | Access                                                            |
+| ------------------------------------------------- | -------------- | ----------------------------------------------------------------- |
+| `/api/health`                                     | GET            | Public. Deployment health only, no learner data                   |
+| `/api/classroom-sessions`                         | GET POST PATCH | Signed-in educator, scoped to their own classes                   |
+| `/api/classroom-sessions/join`                    | POST           | Public with an active code. Issues a classroom credential         |
+| `/api/classroom-sessions/history`                 | GET            | Educator, own classes only                                        |
+| `/api/classroom-sessions/history/:classId`        | GET            | Owning educator or administrator                                  |
+| `/api/classroom-sessions/history/:classId/reopen` | POST           | Owning educator only. No administrator bypass                     |
+| `/api/gameData`                                   | GET POST       | GET administrator; POST owner or credentialed participant         |
+| `/api/gameData/mine`                              | GET            | The caller's own saves, including classroom lineage               |
+| `/api/gameData/:saveId`                           | GET PATCH      | Owner, administrator, or the educator who owns the classroom      |
+| `/api/quiz`, `/api/quiz/:id`                      | GET POST PUT   | Owner or administrator; educators may read within their classroom |
+| `/api/admin/analytics`                            | GET            | Administrator                                                     |
+| `/api/admin/:id/role`                             | PATCH          | Administrator                                                     |
+| `/api/auth/admin-access`                          | GET            | Administrator                                                     |
+| `/api/users`, `/api/users/:id`                    | GET POST PUT   | Administrator                                                     |
+| `/api/users/me`, `/api/users/me/photo`            | GET PATCH      | Signed-in user, own record                                        |
+| `/api/sessions`, `/api/sessions/:sessionId`       | GET POST PATCH | Owner or administrator                                            |
+| `/api/events`                                     | GET POST       | GET administrator; POST owner or credentialed participant         |
 
-**What never crosses the boundary:** stored records contain Clerk ids, quiz ids, and per-question
-answers, and `participantKey` embeds a Clerk id. History and analytics responses are projected views
-— those fields are never read, not merely stripped afterwards.
+Stored records contain Clerk ids, quiz ids, and per-question answers, and `participantKey` embeds a
+Clerk id. History and analytics endpoints return projected views that never select these fields.
 
 Full policy: [api-authorization.md](./api-authorization.md).
 
@@ -145,96 +213,109 @@ Full policy: [api-authorization.md](./api-authorization.md).
 
 ## Testing
 
-Three layers, each with a real blind spot. Knowing where each stops is more useful than the totals.
+| Layer                       | Command             | Covers                                                                           | Does not cover                                                                   |
+| --------------------------- | ------------------- | -------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| Unit (128 tests, 15 files)  | `npm test`          | Authorization decisions, classroom chain logic, scoring, analytics               | The real database; MongoDB is mocked throughout                                  |
+| Browser (18 tests, 2 files) | `npm run test:e2e`  | Both games' completion contracts, save creation and retry, classroom attribution | Authorization, pending a test-only auth stub (issue #69)                         |
+| Accessibility (26 checks)   | `npm run test:a11y` | WCAG 2.1 AA via axe, horizontal overflow at device sizes, reduced motion         | Audio-only instructions, touch target reach, operability of the games themselves |
 
-| Layer              | Command             | Covers                                                                           | Cannot see                                                    |
-| ------------------ | ------------------- | -------------------------------------------------------------------------------- | ------------------------------------------------------------- |
-| Unit (128)         | `npm test`          | Authorization decisions, classroom chain logic, scoring, analytics               | Anything about the real database — MongoDB is mocked          |
-| Browser (18)       | `npm run test:e2e`  | Both games' completion contracts, save creation and retry, classroom attribution | Authorization, until a test-only auth stub exists (issue #69) |
-| Accessibility (26) | `npm run test:a11y` | WCAG 2.1 AA via axe, layout overflow at device sizes, reduced motion             | Audio-only instructions, touch target reach, game operability |
+Unit tests mock MongoDB, so they cover authorization and business logic but not database wiring.
+Connection ordering, index behaviour, and query shape are unverified at that layer. A recent
+high-severity bug, in which a query was issued before the connection was opened and hung for ten
+seconds before failing, was invisible to the whole unit suite and was found by reading the call
+graph.
 
-**The blind spot that has already cost the project:** the highest-severity bug found recently — a
-database call issued before the connection was opened, hanging ten seconds then failing — was
-invisible to all 128 unit tests because they mock MongoDB. It was found by reading the call graph.
-Treat unit tests as covering _decisions_, not _wiring_.
+The accessibility suite reports; it does not gate merges. Known violations remain, so a green
+pipeline does not mean a clean report. The Playwright report is uploaded on every CI run; read it.
+Keyboard focus visibility is checked by hand, because the automated version was timing-dependent and
+was removed.
 
-**Accessibility runs as a reporting step, not a merge gate.** Real violations remain; the Playwright
-report is uploaded on every CI run. Keyboard focus visibility is checked manually — an automated
-version proved timing-dependent and unreliable, and a flaky check is worse than none.
+Both browser suites share one harness in `e2e/support/gameBridge.ts`. Do not add a local copy. The
+States suite kept its own until August 2026; the two drifted, and the stale copy left that suite
+dependent on a live database, where it failed 11 of its 13 tests.
 
----
-
-## Operations
-
-`GET /api/health` is the first thing to check. It separates a database problem from a broken game
-build in one request, carries no learner data, and answers `503` on failure so an uptime monitor can
-alert without parsing the body.
-
-```sh
-curl -s https://<site>/api/health | jq
-```
-
-| Check      | Reports                                                                                                 |
-| ---------- | ------------------------------------------------------------------------------------------------------- |
-| `database` | Connection state. `degraded` means queries would buffer and time out — presents as a hang, not an error |
-| `games`    | Per game: required files present, plus the exact Unity source SHA live. Makes rollback verifiable       |
-| `release`  | The deploying commit, so an alert identifies which version is broken                                    |
-
-**Error reports** are single-line JSON via `reportError` with a correlation id, environment, and
-release. Context accepts **only primitives** — objects and arrays are dropped, so a quiz answer, a
-child's name, or a request body cannot be attached by accident. Scopes stay distinguishable
-(`unity-boot` vs `progress-save`) so alerts can separate them. `setErrorSink` is the seam for a
-hosted tracker.
-
-**When something breaks:** during a live class, **roll back rather than fix forward** — an educator
-with thirty children waiting cannot absorb a fix-and-deploy cycle. Vercel instant rollback takes
-effect immediately with no git operation.
-
-Full runbook: [operations.md](./operations.md).
+CI runs on Node 20 and 22.
 
 ---
 
-## Releasing
+## Releases
 
-**Today `develop` is production.** Vercel deploys production from `develop`, so every merged pull
-request goes live immediately. There is no staging and no moment at which anyone decides to release.
-Until the switch below is thrown, treat every merge as a production change.
+`develop` is currently the production branch. Vercel deploys from it, so every merged pull request
+goes live immediately. There is no staging environment and no separate release step. Treat every
+merge as a production change until the switch below has been made.
 
-The replacement is built: `main` holds what is live, `develop` stays the integration branch, and
-`promote-to-production` fast-forwards `main` to a chosen commit. It refuses anything that is not
-already an ancestor of `develop` **and** has a green CI run for that exact commit — a green run on a
-different commit proves nothing.
+The replacement is already built. `main` holds what is live, `develop` remains the integration
+branch, and the `promote-to-production` workflow fast-forwards `main` to a chosen commit. It refuses
+any commit that is not already an ancestor of `develop` and does not have a passing CI run for that
+exact SHA.
 
-**Consequence that catches people out:** once `main` is production, reverting on `develop` no longer
-changes what is live. You have to promote again.
+Once `main` is the production branch, reverting a commit on `develop` no longer changes what is live.
+The revert must also be promoted.
+
+### Unity builds
+
+Game builds are committed to `public/game/<Game>/`. The `build-unity-webgl` workflow builds a game
+from its source repository and opens a pull request containing only that game's directory. The
+promotion job validates the artifact and builds the site against it before opening the pull request,
+because a pull request opened with the default `GITHUB_TOKEN` does not trigger `on: pull_request`
+workflows and would otherwise arrive with no checks.
+
+The workflow's `source_ref` input accepts a branch, tag, or commit SHA.
 
 Full detail: [releases.md](./releases.md).
 
 ---
 
-## Launch checklist
+## Operations
 
-Six items. None are blocked on code — they need dashboard access, real hardware, or a decision.
-Ordered by risk, not effort.
+`GET /api/health` distinguishes a database problem from a broken game build in a single request. It
+carries no learner data and returns `503` on failure, so an uptime monitor can alert on it without
+parsing the body.
 
-### 1. Run the MongoDB restore drill — highest risk
+```sh
+curl -s https://<site>/api/health | jq
+```
 
-Children's learning records are stored with no verified way to get them back. An untested backup is
-an assumption, not a backup.
+| Field      | Reports                                                                                                                |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `database` | Connection state. `degraded` means queries would buffer and time out, which presents as a hang rather than an error    |
+| `games`    | Per game: whether the required files are present, and the Unity source SHA currently live. Makes a rollback verifiable |
+| `release`  | The deployed commit, so an alert identifies which version is affected                                                  |
 
-- Atlas → Backup → Restore, targeting a **new** cluster, never production
-- `MONGO_URI=<restored-uri> npm run dev`
-- Confirm an educator can open a class and see its roster and quiz results — "the cluster came up"
-  proves nothing
-- Delete the temporary cluster; record the date and who ran it
+Errors are reported through `reportError` as single-line JSON with a correlation id, environment, and
+release. Its context parameter accepts only primitives, so a quiz answer, a child's name, or a
+request body cannot be attached by accident. Scopes such as `unity-boot` and `progress-save` stay
+distinguishable so alerts can separate them. `setErrorSink` is the integration point for a hosted
+tracker.
 
-**Access:** MongoDB Atlas · **Time:** ~1 hour · **Detail:** operations.md
+During a live class, roll back rather than fix forward. An educator with a room of children waiting
+cannot absorb a fix-and-deploy cycle, and Vercel's instant rollback takes effect without a git
+operation.
 
-### 2. Point Vercel's production branch at `main` — needs dashboard
+Full runbook: [operations.md](./operations.md).
 
-The switch that turns the release gate on. All three steps must happen together: a `main` that exists
-while Vercel still deploys `develop` looks authoritative and goes stale immediately, which is why it
-has not been created ahead of time.
+---
+
+## Outstanding work
+
+### Before launch
+
+Five items remain. None are blocked on code; each needs dashboard access, hardware, or a decision.
+
+**1. Run the MongoDB restore drill.** Children's learning records are stored without a verified means
+of recovering them.
+
+- Restore from Atlas → Backup → Restore, targeting a new cluster rather than production.
+- Run `MONGO_URI=<restored-uri> npm run dev`.
+- Confirm an educator can open a class and see its roster and quiz results. Checking only that the
+  cluster starts does not exercise the data.
+- Delete the temporary cluster, and record the date and who ran the drill.
+
+_Requires MongoDB Atlas access. About 1 hour. Detail in operations.md._
+
+**2. Point Vercel's production branch at `main`.** This enables the release gate. All three steps
+belong together, because a `main` branch that exists while Vercel still deploys `develop` looks
+authoritative and goes stale immediately.
 
 ```sh
 git fetch origin
@@ -242,115 +323,60 @@ git branch main origin/develop
 git push origin main
 ```
 
-- Protect both branches — Settings → Branches
-- Vercel → Project → Settings → Git → **Production Branch** → `main`
-- Promote once, confirm with `curl -s https://<site>/api/health | jq .release`
+- Protect both branches under Settings → Branches.
+- Set Vercel → Project → Settings → Git → Production Branch to `main`.
+- Promote once and confirm with `curl -s https://<site>/api/health | jq .release`.
 
-**Access:** Vercel + repo settings · **Time:** ~15 min · **Detail:** releases.md
+_Requires Vercel and repository settings access. About 15 minutes. Detail in releases.md._
 
-### 3. Run the device QA pass — critical path
+**3. Run the device QA pass.** The largest remaining item, and the only one that produces further
+work in the form of a defect list.
 
-The largest remaining item, and the only one whose output is _more work_ — it produces a defect list
-that then needs fixing. Two non-negotiables:
-
-- Run the full loop for both games **twice** — once signed in, once as a classroom participant. Those
+- Run the full loop for both games twice: once signed in, once as a classroom participant. These
   resolve ownership differently and have broken independently.
-- **Play with sound off.** For audio-heavy games aimed at children, audio-only instructions are the
-  most likely failure and the most consequential.
+- Play with sound off. Both games are audio-heavy, and any instruction delivered only as audio will
+  be missed.
+- Confirm the on-screen guides in Penguin Run render. They have been through three rounds of fixes
+  and have never been visually verified.
 
-**Access:** real Chromebook + iPad, with sound · **Time:** ~1 week + fix tail · **Detail:**
-accessibility-qa.md
+_Requires a physical Chromebook and iPad with sound. About 1 week plus a fix tail. Detail in
+accessibility-qa.md._
 
-### 4. Assign an owner to each alert — decision
+**4. Assign an owner to each alert.** Every alert in the runbook needs a named person. The team that
+built the project is graduating, so alerts left unassigned will have no default recipient.
 
-Every alert in the runbook needs a named person. An alert with no owner is a notification everyone
-assumes someone else is handling — which matters more here because the team that built this is
-graduating.
+_No access required. About 30 minutes. Detail in operations.md._
 
-**Access:** none · **Time:** ~30 min · **Detail:** operations.md
+**5. Choose an error-tracking vendor.** `setErrorSink` is the integration point. The choice has been
+deferred because it carries a recurring cost and a data-processing agreement for a product used by
+children. Confirm the vendor does not capture request bodies or session replay by default; the
+reporting layer deliberately excludes answers and names, and session replay would reintroduce them.
 
-### 5. Choose an error-tracking vendor — decision
+_Requires budget approval. About 2 hours once chosen._
 
-`setErrorSink` is the seam. Not chosen deliberately: it carries a recurring cost and a
-data-processing agreement, for a product used by children. Confirm the vendor does **not** capture
-request bodies or session replay by default — the reporting layer keeps answers and names out, and
-session replay would put them straight back in.
+### Status by area
 
-**Access:** budget approval · **Time:** ~2 hours once chosen
-
-### 6. Run the first Unity promotion — never executed
-
-Built but never run; needs Unity licence secrets and a ~90 minute build. Two passes: once with
-`promote` disabled to confirm the build half works, then again with it enabled. Low risk by
-construction — the promotion job can push a branch and open a pull request and nothing else, and a
-failed build opens no pull request.
-
-**Access:** Unity licence secrets · **Time:** ~90 min, mostly waiting
-
----
-
-## Where things stand
-
-| Area                                   | Status                    | Remaining                                           |
-| -------------------------------------- | ------------------------- | --------------------------------------------------- |
-| Learning loop, both games              | Shipped                   | Verification on real devices                        |
-| Classroom sessions, reopening, history | Shipped                   | —                                                   |
-| Admin analytics                        | Shipped                   | —                                                   |
-| Dependency security                    | Clean (0 vulnerabilities) | Six pre-existing React hook warnings need a browser |
-| Observability & health checks (#49)    | Needs a person            | Restore drill, alert owners, vendor choice          |
-| Deployment automation (#48)            | Needs a person            | First promotion run                                 |
-| Accessibility & device QA (#50)        | Needs a person            | The manual pass                                     |
-| End-to-end coverage (#47)              | Open                      | Deterministic database fixtures, per-test seeding   |
-| Browser authorization tests (#69)      | Open                      | A test-only auth stub — not a middleware change     |
+| Area                                   | Status                  | Remaining                                                       |
+| -------------------------------------- | ----------------------- | --------------------------------------------------------------- |
+| Learning loop, both games              | Shipped                 | Verification on real devices                                    |
+| Classroom sessions, reopening, history | Shipped                 | —                                                               |
+| Admin analytics                        | Shipped                 | —                                                               |
+| Dependency security                    | 0 known vulnerabilities | Six pre-existing React hook warnings need a browser to diagnose |
+| Unity build and promotion (#48)        | Shipped                 | —                                                               |
+| Observability and health checks (#49)  | Needs a person          | Restore drill, alert owners, vendor choice                      |
+| Accessibility and device QA (#50)      | Needs a person          | The manual pass                                                 |
+| End-to-end coverage (#47)              | Open                    | Deterministic database fixtures, per-test seeding               |
+| Browser authorization tests (#69)      | Open                    | A test-only auth stub, not a middleware change                  |
 
 ---
 
-## Local setup
-
-1. Clone and `npm install`
-2. Create `.env` with secrets from a tech lead: `MONGO_URI`,
-   `NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`
-3. Install Prettier and ESLint editor extensions; enable format on save
-4. `npm run dev`
-
-**Contributing:** branch from `develop`, not `main`. Run `npm run lint` and `npm test` before opening
-a pull request against `develop`. A Husky hook formats staged files on commit.
-
-| Command                                 | Does                                         |
-| --------------------------------------- | -------------------------------------------- |
-| `npm run dev`                           | Local development server                     |
-| `npm test`                              | 128 unit tests                               |
-| `npm run test:e2e`                      | Browser tests (needs MongoDB)                |
-| `npm run test:a11y`                     | Accessibility report                         |
-| `npm run lint` / `lint:fix`             | ESLint and Prettier                          |
-| `npm audit`                             | Expect 0 vulnerabilities                     |
-| `node scripts/validate-webgl-build.mjs` | Check both embedded game builds are complete |
-
-### Two environment gotchas that look like code bugs
-
-- A local `next build` fails at prerender **without Clerk keys**. Compilation and type-checking still
-  ran, so that failure is environmental. For a full local build:
-  ```sh
-  PK="pk_test_$(printf 'example.clerk.accounts.dev$' | base64 | tr -d '\n')"
-  NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY="$PK" \
-    CLERK_SECRET_KEY="sk_test_0000000000000000000000000000000000000000" \
-    npm run build
-  ```
-- `npx tsc --noEmit` reports pre-existing errors in `e2e/` and `.next/`. Filter with
-  `grep -E '^src/'` to see whether a change is actually clean.
-- **Run `npm install` after switching branches** — dependencies moved substantially.
-- The browser suite needs MongoDB, which is not available in every environment. **CI is the real
-  check** for both the build and the browser tests.
-
----
-
-## Deeper reading
+## Further reading
 
 | Document                                             | Covers                                                                                     |
 | ---------------------------------------------------- | ------------------------------------------------------------------------------------------ |
 | [operations.md](./operations.md)                     | On-call runbook: health checks, alert thresholds, rollback, restore drill, incident triage |
-| [releases.md](./releases.md)                         | Branch topology, migration to `main`, promotion workflow guarantees                        |
-| [accessibility-qa.md](./accessibility-qa.md)         | Device matrix, manual launch pass, automation limits                                       |
+| [releases.md](./releases.md)                         | Branch topology, the migration to `main`, promotion workflow guarantees                    |
+| [accessibility-qa.md](./accessibility-qa.md)         | Device matrix, the manual launch pass, and the limits of the automation                    |
 | [api-authorization.md](./api-authorization.md)       | Route inventory, principals, response conventions                                          |
 | [game-progress-bridge.md](./game-progress-bridge.md) | The contract Unity builds use to report progress                                           |
-| [index.html](./index.html)                           | This handbook, rendered for reading and sharing                                            |
+| [index.html](./index.html)                           | This handbook, formatted for reading and sharing                                           |

--- a/docs/index.html
+++ b/docs/index.html
@@ -590,15 +590,15 @@
 
 <header class="masthead">
   <div class="masthead-inner">
-    <p class="eyebrow">Kids First Initiative · Project Handbook</p>
-    <h1>How this system works, and what is left before it ships</h1>
+    <p class="eyebrow">Kids First Initiative</p>
+    <h1>Project Handbook</h1>
     <p class="lede">
-      A web platform that teaches STEM to children in underserved communities through two Unity games, wrapped in a
-      pre-quiz and post-quiz so a teacher can see what was learned. This page explains the product to whoever needs to
-      understand it — the team maintaining it, and the organisation it belongs to.
+      A web platform that teaches STEM to children in underserved communities. Children play one of two Unity WebGL
+      games and answer a short quiz before and after each one, so that what they learned can be measured. This handbook
+      covers the architecture, the classroom data model, the API, testing, releases, and operations.
     </p>
     <div class="masthead-meta">
-      <span>Updated 29 Aug 2026</span>
+      <span>Updated 31 Aug 2026</span>
       <span>Repo · kids-first-initiative-site</span>
       <span>Integration branch · develop</span>
       <span>Stack · Next 16.3.3 · React 18 · MongoDB · Clerk</span>
@@ -610,234 +610,280 @@
   <nav class="index" aria-label="Sections">
     <h2>Contents</h2>
     <ol>
-      <li><a href="#glance">At a glance</a></li>
-      <li><a href="#product">What it does</a></li>
-      <li><a href="#components">Components</a></li>
-      <li><a href="#classroom">The classroom model</a></li>
-      <li><a href="#api">API surface</a></li>
-      <li><a href="#testing">What is tested</a></li>
-      <li><a href="#operations">Running it</a></li>
-      <li><a href="#releases">Releasing</a></li>
-      <li><a href="#launch">Launch checklist</a></li>
-      <li><a href="#state">Where things stand</a></li>
-      <li><a href="#setup">Local setup</a></li>
-      <li><a href="#deeper">Deeper reading</a></li>
+      <li><a href="#overview">Overview</a></li>
+      <li><a href="#getting-started">Getting started</a></li>
+      <li><a href="#architecture">Architecture</a></li>
+      <li><a href="#classroom">Classroom sessions</a></li>
+      <li><a href="#api">API</a></li>
+      <li><a href="#testing">Testing</a></li>
+      <li><a href="#releases">Releases</a></li>
+      <li><a href="#operations">Operations</a></li>
+      <li><a href="#outstanding">Outstanding work</a></li>
+      <li><a href="#reading">Further reading</a></li>
     </ol>
   </nav>
 
   <main>
-    <!-- ================= AT A GLANCE ================= -->
-    <section id="glance">
-      <h2><span class="num">01</span>At a glance</h2>
-      <p>
-        Every number here is counted from the repository. Each one carries the caveat that matters, because a metric
-        without its limitation invites more confidence than it has earned.
-      </p>
-
-      <div class="metrics">
-        <div class="metric">
-          <span class="label">Unit tests</span>
-          <span class="value">128</span>
-          <span class="caveat"
-            >Across 15 files. All of them mock MongoDB, so connection ordering, index behaviour, and query shape are
-            <em>not</em> verified here.</span
-          >
-        </div>
-        <div class="metric">
-          <span class="label">Browser tests</span>
-          <span class="value">18</span>
-          <span class="caveat"
-            >The only layer exercising real wiring. Covers both games' completion contracts; cannot yet cover
-            authorization.</span
-          >
-        </div>
-        <div class="metric">
-          <span class="label">Accessibility checks</span>
-          <span class="value">26</span>
-          <span class="caveat"
-            >Reports, does not gate. Real violations remain — read the CI artifact rather than trusting a green
-            build.</span
-          >
-        </div>
-        <div class="metric">
-          <span class="label">API endpoints</span>
-          <span class="value">33</span>
-          <span class="caveat"
-            >Across 22 route files. Each one authorizes on the server; client input never assigns ownership.</span
-          >
-        </div>
-        <div class="metric">
-          <span class="label">Known vulnerabilities</span>
-          <span class="value">0</span>
-          <span class="caveat"
-            >Down from 53, including a Clerk middleware auth bypass this app was directly exposed to.</span
-          >
-        </div>
-        <div class="metric">
-          <span class="label">Blocking on a person</span>
-          <span class="value">6</span>
-          <span class="caveat">Access or hardware, not code. All six are in the launch checklist below.</span>
-        </div>
-      </div>
-    </section>
-
-    <!-- ================= PRODUCT ================= -->
-    <section id="product">
-      <h2><span class="num">02</span>What it does</h2>
+    <!-- ================= OVERVIEW ================= -->
+    <section id="overview">
+      <h2>Overview</h2>
 
       <div class="prose">
         <p>
-          The product exists to prove learning happened, not just to entertain. That single goal explains most of its
-          design: every game is bracketed by a quiz, and every result is attributable to a specific child in a specific
-          class.
-        </p>
-        <h3>The learning loop</h3>
-        <p>
-          A learner takes a <strong>pre-quiz</strong>, plays a <strong>game</strong>, then takes a
-          <strong>post-quiz</strong>. The difference between the two is the number the organisation actually cares
-          about. Progress saves continuously during play, so a lost connection or a closed tab does not cost a child
-          their work.
+          Each game is bracketed by a quiz. A child answers the pre-quiz, plays, then answers the post-quiz. The
+          difference between the two scores is the outcome the organisation reports, so every result must be
+          attributable to a particular child in a particular class. Progress saves continuously during play, which means
+          a dropped connection or a closed tab does not lose a child's work.
         </p>
       </div>
 
+      <h3>Games</h3>
       <div class="cards">
         <div class="card">
           <h3>States of Matter</h3>
           <p>
-            Melting, freezing, condensing. Reports progress as completed <em>stage ids</em> — named puzzles rather than
-            numbered levels.
+            Melting, freezing, and condensing. Reports progress as completed <em>stage ids</em>, which are named
+            puzzles.
           </p>
-          <span class="where">public/game/StatesOfMatter/</span>
+          <p class="mono">public/game/StatesOfMatter/</p>
         </div>
         <div class="card">
           <h3>Penguin Run</h3>
           <p>
-            Gravity and friction through track building. Reports progress as completed <em>level numbers</em>, which is
-            why its bridge needs separate test coverage.
+            Gravity and friction, taught through track building. Reports progress as completed <em>level numbers</em>.
           </p>
-          <span class="where">public/game/PenguinRun/</span>
+          <p class="mono">public/game/PenguinRun/</p>
         </div>
       </div>
 
-      <h3>Who uses it</h3>
+      <div class="prose">
+        <p>The two games report progress in different formats, so each has its own browser-test coverage.</p>
+      </div>
+
+      <h3>Roles</h3>
       <div class="table-wrap">
         <table>
           <thead>
             <tr>
-              <th scope="col">Role</th>
-              <th scope="col">What they do</th>
-              <th scope="col">How they are identified</th>
+              <th>Role</th>
+              <th>Capabilities</th>
+              <th>Identified by</th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <td><strong>Learner (classroom)</strong></td>
-              <td>Joins with a class code, plays, takes both quizzes</td>
-              <td>An HTTP-only cookie tied to a participant record. No account needed.</td>
+              <td>Learner (classroom)</td>
+              <td>Joins with a class code, plays, answers both quizzes</td>
+              <td>HTTP-only cookie tied to a participant record</td>
             </tr>
             <tr>
-              <td><strong>Learner (personal)</strong></td>
+              <td>Learner (personal)</td>
               <td>Signs in and plays independently</td>
-              <td>A Clerk account</td>
+              <td>Clerk account</td>
             </tr>
             <tr>
-              <td><strong>Educator</strong></td>
-              <td>Opens a class, shares a code, watches progress, reopens past classes</td>
-              <td>A Clerk account with the educator role, linked to a Teacher record</td>
+              <td>Educator</td>
+              <td>Opens a class, shares the code, monitors progress, reopens past classes</td>
+              <td>Clerk account with the educator role, linked to a <code>Teacher</code> record</td>
             </tr>
             <tr>
-              <td><strong>Administrator</strong></td>
-              <td>Sees cross-class analytics and learning outcomes</td>
-              <td>A Clerk account with the admin role</td>
+              <td>Administrator</td>
+              <td>Cross-class analytics and learning outcomes</td>
+              <td>Clerk account with the admin role</td>
             </tr>
           </tbody>
         </table>
       </div>
 
       <div class="note">
-        <strong>Why classroom learners have no accounts</strong>
+        <strong>Classroom learners do not have accounts</strong>
         <p>
-          The audience is young children on shared school hardware. Requiring each of them to create an account would be
-          a barrier and would collect far more personal data than the product needs. Instead an educator shares a code,
-          and each child becomes a participant identified only by a display name and an opaque cookie.
+          The audience is young children on shared school hardware, where account creation is both a barrier to starting
+          a lesson and a larger collection of personal data than the platform needs. Each child becomes a participant
+          identified by a display name and an opaque cookie.
         </p>
       </div>
     </section>
 
-    <!-- ================= COMPONENTS ================= -->
-    <section id="components">
-      <h2><span class="num">03</span>Components</h2>
-      <p>
-        Ten Mongoose models, 23 pages, and 22 API route files. Rather than list all of them, here is what each part of
-        the system is responsible for and the reasoning that is easy to lose.
-      </p>
+    <!-- ================= GETTING STARTED ================= -->
+    <section id="getting-started">
+      <h2>Getting started</h2>
+
+      <div class="prose">
+        <h3>Prerequisites</h3>
+        <ul>
+          <li>Node.js 20 or 22. CI tests both.</li>
+          <li>A MongoDB connection string.</li>
+          <li>Clerk API keys, obtained from a tech lead.</li>
+        </ul>
+
+        <h3>Setup</h3>
+        <pre><code>npm install
+npm run dev</code></pre>
+        <p>Create a <code>.env</code> file in the repository root with three values:</p>
+        <pre><code>MONGO_URI=
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
+CLERK_SECRET_KEY=</code></pre>
+        <p>
+          There is no <code>.env.example</code> in the repository; the list above is the current requirement. Install
+          the Prettier and ESLint editor extensions and enable format on save. A Husky hook formats staged files on
+          commit.
+        </p>
+      </div>
+
+      <h3>Commands</h3>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Command</th>
+              <th>Purpose</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="mono">npm run dev</td>
+              <td>Development server</td>
+            </tr>
+            <tr>
+              <td class="mono">npm test</td>
+              <td>Unit tests</td>
+            </tr>
+            <tr>
+              <td class="mono">npm run test:e2e</td>
+              <td>Browser tests. Requires MongoDB</td>
+            </tr>
+            <tr>
+              <td class="mono">npm run test:a11y</td>
+              <td>Accessibility report</td>
+            </tr>
+            <tr>
+              <td class="mono">npm run lint</td>
+              <td>ESLint</td>
+            </tr>
+            <tr>
+              <td class="mono">npm run format</td>
+              <td>Prettier</td>
+            </tr>
+            <tr>
+              <td class="mono">npm audit</td>
+              <td>Dependency vulnerabilities</td>
+            </tr>
+            <tr>
+              <td class="mono">node scripts/validate-webgl-build.mjs</td>
+              <td>Verify both embedded game builds are complete</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="prose">
+        <h3>Contributing</h3>
+        <p>
+          Branch from <code>develop</code>. Run <code>npm run lint</code> and <code>npm test</code> before opening a
+          pull request against <code>develop</code>. Do not branch from <code>main</code>; see
+          <a href="#releases">Releases</a> for why it may not exist yet.
+        </p>
+      </div>
+
+      <div class="note">
+        <strong>Environment notes</strong>
+        <p>Several local failures have environmental causes:</p>
+        <ul>
+          <li>
+            <code>next build</code> fails at prerender without Clerk keys. Compilation and type checking have already
+            run by that point. To build locally with placeholder keys, set
+            <code>NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY</code> and <code>CLERK_SECRET_KEY</code> to test values first.
+          </li>
+          <li>
+            <code>npx tsc --noEmit</code> reports pre-existing errors in <code>e2e/</code> and <code>.next/</code>.
+            Filter with <code>grep -E '^src/'</code> to see whether your change is clean.
+          </li>
+          <li>Run <code>npm install</code> after switching branches. Dependencies have moved substantially.</li>
+          <li>
+            The browser suite requires MongoDB, which is not available in every environment. CI is the authoritative
+            check for both the build and the browser tests.
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <!-- ================= ARCHITECTURE ================= -->
+    <section id="architecture">
+      <h2>Architecture</h2>
 
       <div class="cards">
         <div class="card">
-          <h3>Authorization layer</h3>
+          <h3>Authorization</h3>
           <p>
-            API handlers are the security boundary — not page visibility, and never a client-supplied id. Ownership
-            fields are always derived on the server, so a request body cannot claim to be someone else.
+            API handlers are the security boundary. Ownership is derived server-side, never from a client-supplied id.
           </p>
-          <span class="where">src/lib/server/apiAuthorization.ts · classroomAuthorization.ts</span>
+          <p class="mono">src/lib/server/apiAuthorization.ts</p>
         </div>
         <div class="card">
           <h3>Classroom history</h3>
           <p>
-            Pure functions that group sessions into classes, merge rosters across reopens, and compute per-class
-            metrics. Deliberately free of database calls so the logic is testable in isolation.
+            Groups sessions into classes, merges rosters across reopens, computes metrics. Pure functions with no
+            database calls.
           </p>
-          <span class="where">src/lib/server/classroomHistory.ts</span>
+          <p class="mono">src/lib/server/classroomHistory.ts</p>
+        </div>
+        <div class="card">
+          <h3>Classroom data access</h3>
+          <p>Loads class chains and class detail, and performs reopening.</p>
+          <p class="mono">src/lib/server/classroomClasses.ts</p>
         </div>
         <div class="card">
           <h3>Unity bridge</h3>
           <p>
-            The games post progress to the page over <code>postMessage</code>. The site saves it, then routes the
-            learner to the post-quiz exactly once — a second completion signal must not send a child through twice.
+            Receives progress from the game over <code>postMessage</code>, saves it, and routes to the post-quiz once.
           </p>
-          <span class="where">src/components/GamePlayer.tsx · UnityIFrame.tsx</span>
+          <p class="mono">src/components/GamePlayer.tsx</p>
         </div>
         <div class="card">
           <h3>Quiz progress</h3>
-          <p>
-            Reads the baseline a learner recorded before playing. The trickiest code in the system, because the read and
-            write paths must agree on <em>which</em> record belongs to the learner.
-          </p>
-          <span class="where">src/lib/server/quizProgress.ts</span>
+          <p>Reads the baseline score recorded before play.</p>
+          <p class="mono">src/lib/server/quizProgress.ts</p>
         </div>
         <div class="card">
           <h3>Admin analytics</h3>
-          <p>
-            Aggregates outcomes across classes and states which sessions each number covers. Counts classroom learners
-            without requiring a personal account, which the earlier per-user table silently dropped.
-          </p>
-          <span class="where">src/lib/server/adminAnalytics.ts</span>
+          <p>Aggregates outcomes across classes and reports the scope each figure covers.</p>
+          <p class="mono">src/lib/server/adminAnalytics.ts</p>
         </div>
         <div class="card">
           <h3>Observability</h3>
-          <p>
-            Structured error reports with a correlation id and release SHA. Context accepts only primitives, so a quiz
-            answer or a child's name cannot be attached by accident.
-          </p>
-          <span class="where">src/lib/server/observability.ts</span>
+          <p>Structured error reports carrying a correlation id and release SHA.</p>
+          <p class="mono">src/lib/server/observability.ts</p>
+        </div>
+        <div class="card">
+          <h3>Quiz scoring</h3>
+          <p>Score normalisation shared by the dashboards and class history.</p>
+          <p class="mono">src/lib/quizScoring.ts</p>
         </div>
       </div>
-    </section>
-
-    <!-- ================= CLASSROOM MODEL ================= -->
-    <section id="classroom">
-      <h2><span class="num">04</span>The classroom model</h2>
 
       <div class="prose">
         <p>
-          This is the one concept worth understanding before changing anything, because almost every bug in this area
-          has come from misunderstanding it.
+          The repository contains 23 pages under the App Router and 10 Mongoose schemas in <code>src/database/</code>.
+          Hidden links and disabled buttons are user-interface conveniences and carry no security weight. All access
+          decisions are enforced in the API handler.
+        </p>
+      </div>
+    </section>
+
+    <!-- ================= CLASSROOM ================= -->
+    <section id="classroom">
+      <h2>Classroom sessions</h2>
+
+      <div class="prose">
+        <p>
+          Read this section before changing anything that touches a class. Most of the subtle bugs in this project have
+          come from misreading the model below.
         </p>
         <p>
-          <strong>A class is not a session — it is a chain of them.</strong> When an educator reopens a closed class,
-          the system does not revive the old session. It appends a new one linked back to the original through
-          <code>rootSessionId</code>. Historical records keep pointing at the sessions that produced them, so nothing is
-          ever rewritten or re-attributed.
+          A class is a chain of sessions, not a single record. When an educator reopens a closed class, the system
+          appends a new session linked to the previous one; it does not reactivate the old session. Historical records
+          continue to reference the sessions that produced them, so nothing is rewritten or re-attributed.
         </p>
       </div>
 
@@ -845,293 +891,382 @@
         <table>
           <thead>
             <tr>
-              <th scope="col">Concept</th>
-              <th scope="col">Meaning</th>
-              <th scope="col">Consequence</th>
+              <th>Field</th>
+              <th>Meaning</th>
+              <th>Consequence</th>
             </tr>
           </thead>
           <tbody>
             <tr>
               <td class="mono">rootSessionId</td>
               <td>Head of the continuation chain; null on an original session</td>
-              <td>A class is always addressed by <code>rootSessionId ?? _id</code></td>
+              <td>A class is addressed by <code>rootSessionId ?? _id</code></td>
+            </tr>
+            <tr>
+              <td class="mono">continuedFromId</td>
+              <td>The session this one continues</td>
+              <td>Determines chain order</td>
             </tr>
             <tr>
               <td class="mono">participantKey</td>
-              <td>Stable per learner per class — <code>clerk:&lt;id&gt;</code> or <code>guest:&lt;hash&gt;</code></td>
+              <td>Stable per learner per class: <code>clerk:&lt;id&gt;</code> or <code>guest:&lt;hash&gt;</code></td>
               <td>
-                A returning learner is one roster entry, not two. Never send it to a client: it embeds a Clerk id.
+                A returning learner collapses to a single roster entry. It embeds a Clerk id, so it must not be sent to
+                a client
               </td>
             </tr>
             <tr>
               <td class="mono">status + expiresAt</td>
-              <td>Session state is <em>derived</em>, never stored</td>
+              <td>Session state is derived, never stored</td>
               <td>
-                <code>closed</code> means closed; <code>active</code> with a past expiry means expired. Always use
-                <code>resolveClassroomSessionState</code>.
+                <code>closed</code> means closed; <code>active</code> with a past expiry means expired. Use
+                <code>resolveClassroomSessionState</code>
               </td>
             </tr>
             <tr>
               <td class="mono">participant:&lt;id&gt;</td>
-              <td>The owner key on a classroom learner's saves and quiz records</td>
-              <td>
-                Changes when they rejoin after a reopen — lineage resolution is what carries their progress across
-              </td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-
-      <div class="note warn">
-        <strong>One live class per educator, enforced by the database</strong>
-        <p>
-          A unique partial index guarantees at most one active continuation per class, which is what stops two
-          simultaneous reopens leaving a class with two working access codes. It builds in the background; a failure
-          logs <code>ClassroomSession index build failed</code>. If a class ever shows two live sessions, check that
-          index first.
-        </p>
-      </div>
-    </section>
-
-    <!-- ================= API ================= -->
-    <section id="api">
-      <h2><span class="num">05</span>API surface</h2>
-      <p>
-        33 endpoints across 22 route files. Two conventions run through all of them: identity is derived on the server,
-        and an inaccessible resource answers <code>404</code> rather than <code>403</code> so it cannot be probed for.
-      </p>
-
-      <div class="table-wrap">
-        <table>
-          <thead>
-            <tr>
-              <th scope="col">Route</th>
-              <th scope="col">Methods</th>
-              <th scope="col">Who can reach it</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="mono">/api/health</td>
-              <td class="mono">GET</td>
-              <td>Public — deployment health only, no learner data</td>
-            </tr>
-            <tr>
-              <td class="mono">/api/classroom-sessions</td>
-              <td class="mono">GET POST PATCH</td>
-              <td>Signed-in educator; scoped to their own classes</td>
-            </tr>
-            <tr>
-              <td class="mono">/api/classroom-sessions/join</td>
-              <td class="mono">POST</td>
-              <td>Public with an active code; issues the classroom credential</td>
-            </tr>
-            <tr>
-              <td class="mono">/api/classroom-sessions/history</td>
-              <td class="mono">GET</td>
-              <td>Educator; only their own classes</td>
-            </tr>
-            <tr>
-              <td class="mono">/api/classroom-sessions/history/:classId</td>
-              <td class="mono">GET</td>
-              <td>Owning educator, or administrator</td>
-            </tr>
-            <tr>
-              <td class="mono">/api/classroom-sessions/history/:classId/reopen</td>
-              <td class="mono">POST</td>
-              <td>Owning educator only — <strong>no administrator bypass</strong></td>
-            </tr>
-            <tr>
-              <td class="mono">/api/gameData</td>
-              <td class="mono">GET POST</td>
-              <td>GET is administrator; POST is the owner or a credentialed participant</td>
-            </tr>
-            <tr>
-              <td class="mono">/api/gameData/mine</td>
-              <td class="mono">GET</td>
-              <td>The caller's own saves, including their classroom lineage</td>
-            </tr>
-            <tr>
-              <td class="mono">/api/gameData/:saveId</td>
-              <td class="mono">GET PATCH</td>
-              <td>Owner, administrator, or the educator who owns the classroom</td>
-            </tr>
-            <tr>
-              <td class="mono">/api/quiz · /api/quiz/:id</td>
-              <td class="mono">GET POST PUT</td>
-              <td>Owner or administrator; educators read within their classroom</td>
-            </tr>
-            <tr>
-              <td class="mono">/api/admin/analytics</td>
-              <td class="mono">GET</td>
-              <td>Administrator</td>
-            </tr>
-            <tr>
-              <td class="mono">/api/users · /api/users/me · /api/sessions · /api/events</td>
-              <td class="mono">GET POST PATCH PUT</td>
-              <td>Administrator for aggregate reads; self for own records</td>
+              <td>Owner key on a classroom learner's saves and quiz records</td>
+              <td>Changes when a learner rejoins after a reopen; lineage resolution carries their progress across</td>
             </tr>
           </tbody>
         </table>
       </div>
 
       <div class="note">
-        <strong>What never crosses the boundary</strong>
+        <strong>Constraints and lifetime</strong>
         <p>
-          Stored records contain Clerk ids, quiz ids, and per-question answers, and a participant's key embeds a Clerk
-          id. History and analytics responses are projected views — those fields are never read, not merely stripped
-          afterwards. Full policy in <a href="./api-authorization.md">api-authorization.md</a>.
+          A unique partial index permits at most one active continuation per class, which prevents two simultaneous
+          reopens from leaving a class with two working access codes. The index builds in the background, and a failure
+          logs <code>ClassroomSession index build failed</code>. If a class appears to have two live sessions, check the
+          index first.
+        </p>
+        <p>
+          Classroom sessions expire after 8 hours. An educator reporting that a code has stopped working has usually hit
+          the expiry rather than an outage; they can reopen the class from Class History, which issues a new code and
+          retires all previous ones.
+        </p>
+      </div>
+    </section>
+
+    <!-- ================= API ================= -->
+    <section id="api">
+      <h2>API</h2>
+
+      <div class="prose">
+        <p>
+          33 endpoints across 22 route files. Two conventions apply throughout: identity is derived on the server, and a
+          resource the caller cannot access returns <code>404</code> rather than <code>403</code>, so its existence
+          cannot be probed.
+        </p>
+      </div>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Route</th>
+              <th>Methods</th>
+              <th>Access</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="mono">/api/health</td>
+              <td>GET</td>
+              <td>Public. Deployment health only, no learner data</td>
+            </tr>
+            <tr>
+              <td class="mono">/api/classroom-sessions</td>
+              <td>GET POST PATCH</td>
+              <td>Signed-in educator, scoped to their own classes</td>
+            </tr>
+            <tr>
+              <td class="mono">/api/classroom-sessions/join</td>
+              <td>POST</td>
+              <td>Public with an active code. Issues a classroom credential</td>
+            </tr>
+            <tr>
+              <td class="mono">/api/classroom-sessions/history</td>
+              <td>GET</td>
+              <td>Educator, own classes only</td>
+            </tr>
+            <tr>
+              <td class="mono">/api/classroom-sessions/history/:classId</td>
+              <td>GET</td>
+              <td>Owning educator or administrator</td>
+            </tr>
+            <tr>
+              <td class="mono">/api/classroom-sessions/history/:classId/reopen</td>
+              <td>POST</td>
+              <td>Owning educator only. No administrator bypass</td>
+            </tr>
+            <tr>
+              <td class="mono">/api/gameData</td>
+              <td>GET POST</td>
+              <td>GET administrator; POST owner or credentialed participant</td>
+            </tr>
+            <tr>
+              <td class="mono">/api/gameData/mine</td>
+              <td>GET</td>
+              <td>The caller's own saves, including classroom lineage</td>
+            </tr>
+            <tr>
+              <td class="mono">/api/gameData/:saveId</td>
+              <td>GET PATCH</td>
+              <td>Owner, administrator, or the educator who owns the classroom</td>
+            </tr>
+            <tr>
+              <td class="mono">/api/quiz, /api/quiz/:id</td>
+              <td>GET POST PUT</td>
+              <td>Owner or administrator; educators may read within their classroom</td>
+            </tr>
+            <tr>
+              <td class="mono">/api/admin/analytics</td>
+              <td>GET</td>
+              <td>Administrator</td>
+            </tr>
+            <tr>
+              <td class="mono">/api/admin/:id/role</td>
+              <td>PATCH</td>
+              <td>Administrator</td>
+            </tr>
+            <tr>
+              <td class="mono">/api/auth/admin-access</td>
+              <td>GET</td>
+              <td>Administrator</td>
+            </tr>
+            <tr>
+              <td class="mono">/api/users, /api/users/:id</td>
+              <td>GET POST PUT</td>
+              <td>Administrator</td>
+            </tr>
+            <tr>
+              <td class="mono">/api/users/me, /api/users/me/photo</td>
+              <td>GET PATCH</td>
+              <td>Signed-in user, own record</td>
+            </tr>
+            <tr>
+              <td class="mono">/api/sessions, /api/sessions/:sessionId</td>
+              <td>GET POST PATCH</td>
+              <td>Owner or administrator</td>
+            </tr>
+            <tr>
+              <td class="mono">/api/events</td>
+              <td>GET POST</td>
+              <td>GET administrator; POST owner or credentialed participant</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="note">
+        <strong>Fields that never reach a client</strong>
+        <p>
+          Stored records contain Clerk ids, quiz ids, and per-question answers, and <code>participantKey</code> embeds a
+          Clerk id. History and analytics endpoints return projected views that never select these fields. Full policy
+          is in <a href="./api-authorization.md">api-authorization.md</a>.
         </p>
       </div>
     </section>
 
     <!-- ================= TESTING ================= -->
     <section id="testing">
-      <h2><span class="num">06</span>What is tested, and what is not</h2>
-      <p>Three layers, each with a real blind spot. Knowing where each one stops is more useful than the totals.</p>
+      <h2>Testing</h2>
+
+      <div class="metrics">
+        <div class="metric">
+          <span class="label">Unit tests</span>
+          <span class="value">128</span>
+          <span class="caveat">Across 15 files. Run with <code>npm test</code>.</span>
+        </div>
+        <div class="metric">
+          <span class="label">Browser tests</span>
+          <span class="value">18</span>
+          <span class="caveat">Across 2 files. Run with <code>npm run test:e2e</code>.</span>
+        </div>
+        <div class="metric">
+          <span class="label">Accessibility checks</span>
+          <span class="value">26</span>
+          <span class="caveat">Run with <code>npm run test:a11y</code>.</span>
+        </div>
+      </div>
 
       <div class="table-wrap">
         <table>
           <thead>
             <tr>
-              <th scope="col">Layer</th>
-              <th scope="col">Command</th>
-              <th scope="col">Covers</th>
-              <th scope="col">Cannot see</th>
+              <th>Layer</th>
+              <th>Covers</th>
+              <th>Does not cover</th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <td><strong>Unit</strong> · 128</td>
-              <td class="mono">npm test</td>
+              <td>Unit</td>
               <td>Authorization decisions, classroom chain logic, scoring, analytics</td>
-              <td>Anything about the real database — MongoDB is mocked throughout</td>
+              <td>The real database; MongoDB is mocked throughout</td>
             </tr>
             <tr>
-              <td><strong>Browser</strong> · 18</td>
-              <td class="mono">npm run test:e2e</td>
+              <td>Browser</td>
               <td>Both games' completion contracts, save creation and retry, classroom attribution</td>
-              <td>Authorization, until a test-only auth stub exists (issue #69)</td>
+              <td>Authorization, pending a test-only auth stub (issue #69)</td>
             </tr>
             <tr>
-              <td><strong>Accessibility</strong> · 26</td>
-              <td class="mono">npm run test:a11y</td>
-              <td>WCAG 2.1 AA via axe, layout overflow at real device sizes, reduced motion</td>
-              <td>Audio-only instructions, touch target reach, whether a game is operable</td>
+              <td>Accessibility</td>
+              <td>WCAG 2.1 AA via axe, horizontal overflow at device sizes, reduced motion</td>
+              <td>Audio-only instructions, touch target reach, operability of the games themselves</td>
             </tr>
           </tbody>
         </table>
       </div>
 
-      <div class="note warn">
-        <strong>The blind spot that has already cost the project</strong>
-        <p>
-          The highest-severity bug found recently — a database call issued before the connection was opened, which hung
-          for ten seconds and then failed — was invisible to all 128 unit tests, because they mock MongoDB. It was found
-          by reading the call graph. Treat unit tests as covering <em>decisions</em>, not <em>wiring</em>.
-        </p>
-      </div>
-    </section>
-
-    <!-- ================= OPERATIONS ================= -->
-    <section id="operations">
-      <h2><span class="num">07</span>Running it</h2>
-
       <div class="prose">
         <p>
-          <code>GET /api/health</code> is the first thing to check when something looks wrong. It separates a database
-          problem from a broken game build in a single request, carries no learner data, and answers <code>503</code> on
-          failure so an uptime monitor can alert without parsing anything.
+          Unit tests mock MongoDB, so they cover authorization and business logic but not database wiring. Connection
+          ordering, index behaviour, and query shape are unverified at that layer. A recent high-severity bug, in which
+          a query was issued before the connection was opened and hung for ten seconds before failing, was invisible to
+          the whole unit suite and was found by reading the call graph.
         </p>
-      </div>
-
-      <pre><code>curl -s https://&lt;site&gt;/api/health | jq</code></pre>
-
-      <div class="cards">
-        <div class="card">
-          <h3>Database</h3>
-          <p>
-            Reports the connection state. <code>degraded</code> means queries would buffer and eventually time out —
-            which presents to a user as a hang, not an error.
-          </p>
-        </div>
-        <div class="card">
-          <h3>Game builds</h3>
-          <p>
-            Per game: whether the required files are present, plus the exact Unity source SHA that is live. This is what
-            makes a rollback verifiable instead of assumed.
-          </p>
-        </div>
-        <div class="card">
-          <h3>Release</h3>
-          <p>The deploying commit, so an alert identifies which version is broken rather than just "production".</p>
-        </div>
-      </div>
-
-      <div class="prose">
-        <h3>When something breaks</h3>
         <p>
-          During a live class, <strong>roll back rather than fix forward</strong> — an educator with thirty children
-          waiting cannot absorb a fix-and-deploy cycle. Vercel's instant rollback takes effect immediately and needs no
-          git operation. Full triage steps, alert thresholds, and the backup restore procedure are in
-          <a href="./operations.md">operations.md</a>.
+          The accessibility suite reports; it does not gate merges. Known violations remain, so a green pipeline does
+          not mean a clean report. The Playwright report is uploaded on every CI run; read it. Keyboard focus visibility
+          is checked by hand, because the automated version was timing-dependent and was removed.
         </p>
+        <p>
+          Both browser suites share one harness in <code>e2e/support/gameBridge.ts</code>. Do not add a local copy. The
+          States suite kept its own until August 2026; the two drifted, and the stale copy left that suite dependent on
+          a live database, where it failed 11 of its 13 tests.
+        </p>
+        <p>CI runs on Node 20 and 22.</p>
       </div>
     </section>
 
     <!-- ================= RELEASES ================= -->
     <section id="releases">
-      <h2><span class="num">08</span>Releasing</h2>
+      <h2>Releases</h2>
 
-      <div class="note warn">
-        <strong>Today, <code>develop</code> is production</strong>
+      <div class="note">
+        <strong><code>develop</code> is currently the production branch</strong>
         <p>
-          Vercel deploys production from <code>develop</code>, so every merged pull request goes live immediately. There
-          is no staging and no moment at which anyone decides to release. Until the switch in the checklist below is
-          thrown, treat every merge as a production change.
+          Vercel deploys from it, so every merged pull request goes live immediately. There is no staging environment
+          and no separate release step. Treat every merge as a production change until the switch described below has
+          been made.
         </p>
       </div>
 
       <div class="prose">
         <p>
-          The replacement is already built: <code>main</code> holds what is live, <code>develop</code> stays the
+          The replacement is already built. <code>main</code> holds what is live, <code>develop</code> remains the
           integration branch, and the <code>promote-to-production</code> workflow fast-forwards <code>main</code> to a
-          chosen commit. It refuses anything that is not already an ancestor of <code>develop</code> with a green CI run
-          for that exact commit — a green run on a <em>different</em> commit proves nothing.
+          chosen commit. It refuses any commit that is not already an ancestor of <code>develop</code> and does not have
+          a passing CI run for that exact SHA.
         </p>
         <p>
-          One consequence catches people out: once <code>main</code> is production, reverting on <code>develop</code> no
-          longer changes what is live. You have to promote again.
+          Once <code>main</code> is the production branch, reverting a commit on <code>develop</code> no longer changes
+          what is live. The revert must also be promoted.
+        </p>
+
+        <h3>Unity builds</h3>
+        <p>
+          Game builds are committed to <code>public/game/&lt;Game&gt;/</code>. The
+          <code>build-unity-webgl</code> workflow builds a game from its source repository and opens a pull request
+          containing only that game's directory. The promotion job validates the artifact and builds the site against it
+          before opening the pull request, because a pull request opened with the default <code>GITHUB_TOKEN</code> does
+          not trigger <code>on: pull_request</code> workflows and would otherwise arrive with no checks. The workflow's
+          <code>source_ref</code> input accepts a branch, tag, or commit SHA.
+        </p>
+        <p>Full detail is in <a href="./releases.md">releases.md</a>.</p>
+      </div>
+    </section>
+
+    <!-- ================= OPERATIONS ================= -->
+    <section id="operations">
+      <h2>Operations</h2>
+
+      <div class="prose">
+        <p>
+          <code>GET /api/health</code> distinguishes a database problem from a broken game build in a single request. It
+          carries no learner data and returns <code>503</code> on failure, so an uptime monitor can alert on it without
+          parsing the body.
+        </p>
+        <pre><code>curl -s https://&lt;site&gt;/api/health | jq</code></pre>
+      </div>
+
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Field</th>
+              <th>Reports</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td class="mono">database</td>
+              <td>
+                Connection state. <code>degraded</code> means queries would buffer and time out, which presents as a
+                hang rather than an error
+              </td>
+            </tr>
+            <tr>
+              <td class="mono">games</td>
+              <td>
+                Per game: whether the required files are present, and the Unity source SHA currently live. Makes a
+                rollback verifiable
+              </td>
+            </tr>
+            <tr>
+              <td class="mono">release</td>
+              <td>The deployed commit, so an alert identifies which version is affected</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="prose">
+        <p>
+          Errors are reported through <code>reportError</code> as single-line JSON with a correlation id, environment,
+          and release. Its context parameter accepts only primitives, so a quiz answer, a child's name, or a request
+          body cannot be attached by accident. Scopes such as <code>unity-boot</code> and
+          <code>progress-save</code> stay distinguishable so alerts can separate them. <code>setErrorSink</code> is the
+          integration point for a hosted tracker.
+        </p>
+      </div>
+
+      <div class="note">
+        <strong>During a live class, roll back rather than fix forward</strong>
+        <p>
+          An educator with a room of children waiting cannot absorb a fix-and-deploy cycle, and Vercel's instant
+          rollback takes effect without a git operation. Full runbook is in
+          <a href="./operations.md">operations.md</a>.
         </p>
       </div>
     </section>
 
-    <!-- ================= LAUNCH CHECKLIST ================= -->
-    <section id="launch">
-      <h2><span class="num">09</span>Launch checklist</h2>
-      <p>
-        Six items. None of them are blocked on code — they need dashboard access, real hardware, or a decision. They are
-        ordered by risk, not by effort.
-      </p>
+    <!-- ================= OUTSTANDING ================= -->
+    <section id="outstanding">
+      <h2>Outstanding work</h2>
+
+      <div class="prose">
+        <h3>Before launch</h3>
+        <p>Five items remain. None are blocked on code; each needs dashboard access, hardware, or a decision.</p>
+      </div>
 
       <div class="checklist">
-        <article class="task blocker">
+        <article class="task">
           <div class="task-head">
             <h3>Run the MongoDB restore drill</h3>
-            <span class="pill pill-human">Highest risk</span>
+            <span class="pill pill-human">Needs Atlas access</span>
           </div>
-          <p>
-            You are storing children's learning records with no verified way to get them back. Atlas is presumably
-            taking backups, but nobody has restored from one — and an untested backup is an assumption, not a backup.
-          </p>
+          <p>Children's learning records are stored without a verified means of recovering them.</p>
           <ol class="steps">
-            <li>Atlas → Backup → Restore, targeting a <strong>new</strong> cluster, never production.</li>
-            <li>Point a local checkout at it: <code>MONGO_URI=&lt;restored-uri&gt; npm run dev</code></li>
+            <li>Restore from Atlas → Backup → Restore, targeting a <strong>new</strong> cluster, never production.</li>
+            <li>Run <code>MONGO_URI=&lt;restored-uri&gt; npm run dev</code></li>
             <li>
-              Confirm an educator can open a class and see its roster and quiz results — "the cluster came up" proves
-              nothing.
+              Confirm an educator can open a class and see its roster and quiz results. Checking only that the cluster
+              starts does not exercise the data.
             </li>
-            <li>Delete the temporary cluster, and record the date and who ran it.</li>
+            <li>Delete the temporary cluster, and record the date and who ran the drill.</li>
           </ol>
           <div class="task-meta">
             <span><b>Access</b> MongoDB Atlas</span><span><b>Time</b> ~1 hour</span
@@ -1139,23 +1274,22 @@
           </div>
         </article>
 
-        <article class="task blocker">
+        <article class="task">
           <div class="task-head">
             <h3>Point Vercel's production branch at <code>main</code></h3>
             <span class="pill pill-human">Needs dashboard</span>
           </div>
           <p>
-            This is the switch that turns the release gate on. All three steps must happen together — a
-            <code>main</code> branch that exists while Vercel still deploys <code>develop</code> looks authoritative and
-            goes stale immediately, which is why it has not been created ahead of time.
+            This enables the release gate. All three steps belong together, because a <code>main</code> branch that
+            exists while Vercel still deploys <code>develop</code> looks authoritative and goes stale immediately.
           </p>
-          <pre><code>git fetch origin
-git branch main origin/develop
-git push origin main</code></pre>
           <ol class="steps">
-            <li>Protect both branches — Settings → Branches.</li>
-            <li>Vercel → Project → Settings → Git → <strong>Production Branch</strong> → <code>main</code>.</li>
-            <li>Promote once and confirm: <code>curl -s https://&lt;site&gt;/api/health | jq .release</code></li>
+            <li>
+              <code>git fetch origin &amp;&amp; git branch main origin/develop &amp;&amp; git push origin main</code>
+            </li>
+            <li>Protect both branches under Settings → Branches.</li>
+            <li>Set Vercel → Project → Settings → Git → Production Branch to <code>main</code>.</li>
+            <li>Promote once and confirm with <code>curl -s https://&lt;site&gt;/api/health | jq .release</code></li>
           </ol>
           <div class="task-meta">
             <span><b>Access</b> Vercel + repo settings</span><span><b>Time</b> ~15 min</span
@@ -1163,88 +1297,71 @@ git push origin main</code></pre>
           </div>
         </article>
 
-        <article class="task blocker">
+        <article class="task">
           <div class="task-head">
             <h3>Run the device QA pass</h3>
-            <span class="pill pill-human">Critical path</span>
+            <span class="pill pill-human">Needs hardware</span>
           </div>
-          <p>
-            The largest remaining item, and the only one whose output is <em>more work</em> — it produces a defect list
-            that then needs fixing. Two things it insists on: run the full loop for both games
-            <strong>twice</strong> (once signed in, once as a classroom participant, because those resolve ownership
-            differently and have broken independently), and <strong>play with sound off</strong>. For audio-heavy games
-            aimed at children, audio-only instructions are the most likely failure and the most consequential.
-          </p>
+          <p>The largest remaining item, and the only one that produces further work in the form of a defect list.</p>
+          <ol class="steps">
+            <li>
+              Run the full loop for both games twice: once signed in, once as a classroom participant. These resolve
+              ownership differently and have broken independently.
+            </li>
+            <li>
+              Play with sound off. Both games are audio-heavy, and any instruction delivered only as audio will be
+              missed.
+            </li>
+            <li>
+              Confirm the on-screen guides in Penguin Run render. They have been through three rounds of fixes and have
+              never been visually verified.
+            </li>
+          </ol>
           <div class="task-meta">
-            <span><b>Access</b> real Chromebook + iPad, with sound</span><span><b>Time</b> ~1 week + fix tail</span
+            <span><b>Access</b> Chromebook + iPad, with sound</span><span><b>Time</b> ~1 week + fix tail</span
             ><span><b>Detail</b> accessibility-qa.md</span>
           </div>
         </article>
 
-        <article class="task decision">
+        <article class="task">
           <div class="task-head">
             <h3>Assign an owner to each alert</h3>
-            <span class="pill pill-open">Decision</span>
+            <span class="pill pill-human">Decision</span>
           </div>
           <p>
-            The runbook defines thresholds and a first response for each alert. Every one needs a named person. An alert
-            with no owner is a notification everyone assumes someone else is handling — which matters more than usual
-            here, because the team that built this is graduating.
+            Every alert in the runbook needs a named person. The team that built the project is graduating, so alerts
+            left unassigned will have no default recipient.
           </p>
           <div class="task-meta">
-            <span><b>Access</b> none — a decision</span><span><b>Time</b> ~30 min</span
-            ><span><b>Detail</b> operations.md</span>
+            <span><b>Access</b> None</span><span><b>Time</b> ~30 min</span><span><b>Detail</b> operations.md</span>
           </div>
         </article>
 
-        <article class="task decision">
+        <article class="task">
           <div class="task-head">
             <h3>Choose an error-tracking vendor</h3>
-            <span class="pill pill-open">Decision</span>
+            <span class="pill pill-human">Decision</span>
           </div>
           <p>
-            <code>setErrorSink</code> is the seam — wire it once and every existing call site reports to your tool. Not
-            chosen deliberately: it carries a recurring cost and a data-processing agreement, for a product used by
-            children. When choosing, confirm the vendor does <strong>not</strong> capture request bodies or session
-            replay by default; the reporting layer is careful to keep answers and names out, and session replay would
-            put them straight back in.
+            <code>setErrorSink</code> is the integration point. The choice has been deferred because it carries a
+            recurring cost and a data-processing agreement for a product used by children. Confirm the vendor does not
+            capture request bodies or session replay by default; the reporting layer deliberately excludes answers and
+            names, and session replay would reintroduce them.
           </p>
           <div class="task-meta">
-            <span><b>Access</b> budget approval</span><span><b>Time</b> ~2 hours once chosen</span
-            ><span><b>Detail</b> operations.md</span>
-          </div>
-        </article>
-
-        <article class="task decision">
-          <div class="task-head">
-            <h3>Run the first Unity promotion</h3>
-            <span class="pill pill-open">Never executed</span>
-          </div>
-          <p>
-            The automation is built but has never run — it needs Unity licence secrets and a ~90 minute build. Do it in
-            two passes: once with <code>promote</code> disabled to confirm the build half works, then again with it
-            enabled. Low risk by construction: the promotion job can push a branch and open a pull request and nothing
-            else, and a failed build opens no pull request at all.
-          </p>
-          <div class="task-meta">
-            <span><b>Access</b> Unity licence secrets</span><span><b>Time</b> ~90 min, mostly waiting</span
-            ><span><b>Detail</b> Actions → build-unity-webgl</span>
+            <span><b>Access</b> Budget approval</span><span><b>Time</b> ~2 hours once chosen</span>
           </div>
         </article>
       </div>
-    </section>
 
-    <!-- ================= STATE ================= -->
-    <section id="state">
-      <h2><span class="num">10</span>Where things stand</h2>
-
+      <h3>Status by area</h3>
       <div class="table-wrap">
         <table>
           <thead>
             <tr>
-              <th scope="col">Area</th>
-              <th scope="col">Status</th>
-              <th scope="col">What remains</th>
+              <th>Area</th>
+              <th>Status</th>
+              <th>Remaining</th>
             </tr>
           </thead>
           <tbody>
@@ -1265,149 +1382,69 @@ git push origin main</code></pre>
             </tr>
             <tr>
               <td>Dependency security</td>
-              <td><span class="pill pill-done">Clean</span></td>
-              <td>Six pre-existing React hook warnings need a browser to verify</td>
+              <td><span class="pill pill-done">0 known</span></td>
+              <td>Six pre-existing React hook warnings need a browser to diagnose</td>
             </tr>
             <tr>
-              <td>Observability &amp; health checks (#49)</td>
+              <td>Unity build and promotion (#48)</td>
+              <td><span class="pill pill-done">Shipped</span></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td>Observability and health checks (#49)</td>
               <td><span class="pill pill-human">Needs a person</span></td>
               <td>Restore drill, alert owners, vendor choice</td>
             </tr>
             <tr>
-              <td>Deployment automation (#48)</td>
+              <td>Accessibility and device QA (#50)</td>
               <td><span class="pill pill-human">Needs a person</span></td>
-              <td>First promotion run</td>
-            </tr>
-            <tr>
-              <td>Accessibility &amp; device QA (#50)</td>
-              <td><span class="pill pill-human">Needs a person</span></td>
-              <td>The manual pass; real violations recorded in CI</td>
+              <td>The manual pass</td>
             </tr>
             <tr>
               <td>End-to-end coverage (#47)</td>
               <td><span class="pill pill-open">Open</span></td>
-              <td>Deterministic database fixtures and per-test seeding</td>
+              <td>Deterministic database fixtures, per-test seeding</td>
             </tr>
             <tr>
               <td>Browser authorization tests (#69)</td>
               <td><span class="pill pill-open">Open</span></td>
-              <td>A test-only auth stub — not a middleware change</td>
+              <td>A test-only auth stub, not a middleware change</td>
             </tr>
           </tbody>
         </table>
       </div>
     </section>
 
-    <!-- ================= SETUP ================= -->
-    <section id="setup">
-      <h2><span class="num">11</span>Local setup</h2>
-
-      <ol class="steps">
-        <li>Clone the repository and run <code>npm install</code>.</li>
-        <li>
-          Create <code>.env</code> and get the secrets from a tech lead: <code>MONGO_URI</code>,
-          <code>NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY</code>, <code>CLERK_SECRET_KEY</code>.
-        </li>
-        <li>Install the Prettier and ESLint editor extensions, and enable format on save.</li>
-        <li><code>npm run dev</code>.</li>
-      </ol>
-
-      <div class="prose">
-        <h3>Contributing</h3>
-        <p>
-          Branch from <code>develop</code> — not <code>main</code>. Run <code>npm run lint</code> and
-          <code>npm test</code> before opening a pull request against <code>develop</code>. A Husky hook formats staged
-          files on commit.
-        </p>
-      </div>
-
-      <div class="table-wrap">
-        <table>
-          <thead>
-            <tr>
-              <th scope="col">Command</th>
-              <th scope="col">What it does</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td class="mono">npm run dev</td>
-              <td>Local development server</td>
-            </tr>
-            <tr>
-              <td class="mono">npm test</td>
-              <td>128 unit tests</td>
-            </tr>
-            <tr>
-              <td class="mono">npm run test:e2e</td>
-              <td>Browser tests (needs MongoDB)</td>
-            </tr>
-            <tr>
-              <td class="mono">npm run test:a11y</td>
-              <td>Accessibility report</td>
-            </tr>
-            <tr>
-              <td class="mono">npm run lint</td>
-              <td>ESLint and Prettier</td>
-            </tr>
-            <tr>
-              <td class="mono">node scripts/validate-webgl-build.mjs</td>
-              <td>Check both embedded game builds are complete</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
-
-      <div class="note">
-        <strong>Two environment gotchas that look like code bugs</strong>
-        <p>
-          A local <code>next build</code> fails at prerender without Clerk keys — compilation and type-checking still
-          ran, so that failure is environmental. And <code>npx tsc --noEmit</code> reports pre-existing errors in
-          <code>e2e/</code> and <code>.next/</code>; filter with <code>grep -E '^src/'</code> to see whether your change
-          is actually clean.
-        </p>
-      </div>
-    </section>
-
-    <!-- ================= DEEPER ================= -->
-    <section id="deeper">
-      <h2><span class="num">12</span>Deeper reading</h2>
-      <p>This page is the map. Each of these goes properly into one area.</p>
+    <!-- ================= FURTHER READING ================= -->
+    <section id="reading">
+      <h2>Further reading</h2>
 
       <div class="cards">
         <div class="card">
-          <h3><a href="./operations.md">operations.md</a></h3>
-          <p>
-            On-call runbook: health checks, alert thresholds, rollback for both the site and a game build, backup
-            restore drill, incident triage.
-          </p>
+          <h3>operations.md</h3>
+          <p>On-call runbook: health checks, alert thresholds, rollback, restore drill, incident triage.</p>
         </div>
         <div class="card">
-          <h3><a href="./releases.md">releases.md</a></h3>
-          <p>Branch topology, the migration to <code>main</code>, and the promotion workflow's guarantees.</p>
+          <h3>releases.md</h3>
+          <p>Branch topology, the migration to <code>main</code>, promotion workflow guarantees.</p>
         </div>
         <div class="card">
-          <h3><a href="./accessibility-qa.md">accessibility-qa.md</a></h3>
-          <p>Device matrix, the manual launch pass, and what automation can and cannot judge.</p>
+          <h3>accessibility-qa.md</h3>
+          <p>Device matrix, the manual launch pass, and the limits of the automation.</p>
         </div>
         <div class="card">
-          <h3><a href="./api-authorization.md">api-authorization.md</a></h3>
-          <p>Full route inventory, principals, response conventions, and the classroom history rules.</p>
+          <h3>api-authorization.md</h3>
+          <p>Route inventory, principals, response conventions.</p>
         </div>
         <div class="card">
-          <h3><a href="./game-progress-bridge.md">game-progress-bridge.md</a></h3>
-          <p>The contract Unity builds use to report progress to the site.</p>
+          <h3>game-progress-bridge.md</h3>
+          <p>The contract Unity builds use to report progress.</p>
         </div>
         <div class="card">
-          <h3><a href="./handbook.md">handbook.md</a></h3>
-          <p>This page as plain Markdown — the version to search, grep, or hand to an AI assistant.</p>
+          <h3>handbook.md</h3>
+          <p>This page as plain text, for search and for reading in the repository.</p>
         </div>
       </div>
     </section>
   </main>
 </div>
-
-<footer>
-  Kids First Initiative · Cal Poly Hack4Impact · Handbook generated from the repository on 29 August 2026. Numbers
-  reflect that commit; re-count before quoting them.
-</footer>


### PR DESCRIPTION
The handbook read like an essay *about* the project instead of documentation *for* it. This rewrites it, and fixes the factual drift found along the way.

## What was wrong with the voice

| Measure | Before | After |
| --- | ---: | ---: |
| Bolded sentence-openers | 24 | 0 |
| Inline `**Bold lead-in:**` | 31 | 5 |
| Em-dashes | 37 | 4 |
| Aphorisms | 5 | 0 |

The aphorisms are the clearest example — *"an untested backup is an assumption, not a backup"*, *"a flaky check is worse than none"*, *"a metric without its limitation invites more confidence than it has earned"*. Each states something true, but documentation states the fact and moves on; it doesn't editorialise.

The other recurring habit was explaining the document's own reasoning. The metrics table led with *"Each number carries its limitation, because…"* — narrating the doc's epistemics rather than documenting the system.

## Structural changes

- **Getting started moved near the front.** It was section 11 of 12. Setup is what most readers need first.
- **The metrics table is gone.** Test counts now live in Testing, endpoint counts in API, where the caveats attach to the layer being described.
- **The rendered page loses its `01`–`12` numbering** and the essay title *"How this system works, and what is left before it ships"*. Numbered markers imply a sequence; a handbook's sections aren't one.
- Contents list, consistent heading levels, and a `Last updated` date.

## Corrections found while rewriting

These are the reason a rewrite was worth doing rather than a reformat:

- **Setup told readers to `cp .env.example .env`.** That file does not exist in the repository — I wrote that line into the first draft myself and caught it when verifying the instructions actually run. It now lists the three required variables and states the file is absent.
- **`npm run format` was missing** from the command table, and `lint` was described as running Prettier. It doesn't; `format` does.
- **The Unity promotion was still listed as never executed.** It has run. The launch checklist is five items, not six.
- Added **Node 20 and 22** as supported versions, matching the CI matrix.
- Added the shared e2e harness rule and `source_ref` behaviour, both learned the hard way this week.

## Verification

- Every figure recounted from the repository: 128 unit tests / 15 files, 18 browser tests / 2 files, 26 accessibility checks, 33 endpoints / 22 route files, 23 pages, 10 schemas, 0 vulnerabilities.
- All six cross-document links resolve; all ten anchors resolve.
- `index.html` parses with balanced tags; all nav anchors match a section id.
- Both files prettier-formatted.

Content is otherwise preserved — the classroom chain model, the API table, the environment gotchas, and the launch checklist detail all survive with the same technical substance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)