### PR TITLE
Stop file paths overflowing their cards in the handbook

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -438,6 +438,9 @@
     flex-direction: column;
     gap: 9px;
     box-shadow: var(--shadow);
+    /* Grid items default to min-width:auto, which lets an unbreakable token such as a file
+       path widen the track and spill past the card edge. */
+    min-width: 0;
   }
 
   .card h3 {
@@ -645,14 +648,14 @@
             Melting, freezing, and condensing. Reports progress as completed <em>stage ids</em>, which are named
             puzzles.
           </p>
-          <p class="mono">public/game/StatesOfMatter/</p>
+          <p class="where">public/game/StatesOfMatter/</p>
         </div>
         <div class="card">
           <h3>Penguin Run</h3>
           <p>
             Gravity and friction, taught through track building. Reports progress as completed <em>level numbers</em>.
           </p>
-          <p class="mono">public/game/PenguinRun/</p>
+          <p class="where">public/game/PenguinRun/</p>
         </div>
       </div>
 
@@ -818,7 +821,7 @@ CLERK_SECRET_KEY=</code></pre>
           <p>
             API handlers are the security boundary. Ownership is derived server-side, never from a client-supplied id.
           </p>
-          <p class="mono">src/lib/server/apiAuthorization.ts</p>
+          <p class="where">src/lib/server/apiAuthorization.ts</p>
         </div>
         <div class="card">
           <h3>Classroom history</h3>
@@ -826,39 +829,39 @@ CLERK_SECRET_KEY=</code></pre>
             Groups sessions into classes, merges rosters across reopens, computes metrics. Pure functions with no
             database calls.
           </p>
-          <p class="mono">src/lib/server/classroomHistory.ts</p>
+          <p class="where">src/lib/server/classroomHistory.ts</p>
         </div>
         <div class="card">
           <h3>Classroom data access</h3>
           <p>Loads class chains and class detail, and performs reopening.</p>
-          <p class="mono">src/lib/server/classroomClasses.ts</p>
+          <p class="where">src/lib/server/classroomClasses.ts</p>
         </div>
         <div class="card">
           <h3>Unity bridge</h3>
           <p>
             Receives progress from the game over <code>postMessage</code>, saves it, and routes to the post-quiz once.
           </p>
-          <p class="mono">src/components/GamePlayer.tsx</p>
+          <p class="where">src/components/GamePlayer.tsx</p>
         </div>
         <div class="card">
           <h3>Quiz progress</h3>
           <p>Reads the baseline score recorded before play.</p>
-          <p class="mono">src/lib/server/quizProgress.ts</p>
+          <p class="where">src/lib/server/quizProgress.ts</p>
         </div>
         <div class="card">
           <h3>Admin analytics</h3>
           <p>Aggregates outcomes across classes and reports the scope each figure covers.</p>
-          <p class="mono">src/lib/server/adminAnalytics.ts</p>
+          <p class="where">src/lib/server/adminAnalytics.ts</p>
         </div>
         <div class="card">
           <h3>Observability</h3>
           <p>Structured error reports carrying a correlation id and release SHA.</p>
-          <p class="mono">src/lib/server/observability.ts</p>
+          <p class="where">src/lib/server/observability.ts</p>
         </div>
         <div class="card">
           <h3>Quiz scoring</h3>
           <p>Score normalisation shared by the dashboards and class history.</p>
-          <p class="mono">src/lib/quizScoring.ts</p>
+          <p class="where">src/lib/quizScoring.ts</p>
         </div>
       </div>
 


### PR DESCRIPTION
Reported with a screenshot: the file paths under each architecture card run past the card's right edge and clip mid-word.

## Cause

My regression from the handbook rewrite (#80). The path paragraphs were given the generic `.mono` class, which sets a font family and size and nothing else. A file path contains no spaces, so it has nowhere to wrap.

The stylesheet already carries a class for exactly this case:

```css
.card .where {
  font-family: "IBM Plex Mono", ui-monospace, monospace;
  font-size: 11.5px;
  color: var(--ink-faint);
  word-break: break-all;
}
```

The previous version of the page used `.where` on all 8 of its paths and did not overflow. The rewrite replaced it with `.mono` and lost the wrapping, the smaller size, and the faint colour. Restored on all 10.

## Also

`min-width: 0` on `.card`. Grid items default to `min-width: auto`, which lets an unbreakable token widen its own track — so a long enough path could push the card out even with wrapping available on the text.

## Verification

Structural, not visual: all 10 `.where` elements are confirmed inside a `.card`, so the descendant selector applies, and `pre` and `.table-wrap` were checked separately (both already scroll on their own, so the cards were the only leak).

**The browser extension is not connected in this environment, so I have not seen the fix render.** The reasoning is that this restores the exact class the page used before the regression, on a layout that did not overflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)